### PR TITLE
feat: 初回セットアップを自動化するスクリプトと chezmoi 設定を追加

### DIFF
--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -1,0 +1,1 @@
+sourceDir = "{{ .chezmoi.sourceDir }}"

--- a/home/dot_bashrc
+++ b/home/dot_bashrc
@@ -47,12 +47,12 @@ esac
 
 if [ -n "$force_color_prompt" ]; then
     if [ -x /usr/bin/tput ] && tput setaf 1 >&/dev/null; then
-	# We have color support; assume it's compliant with Ecma-48
-	# (ISO/IEC-6429). (Lack of such support is extremely rare, and such
-	# a case would tend to support setf rather than setaf.)
-	color_prompt=yes
+        # We have color support; assume it's compliant with Ecma-48
+        # (ISO/IEC-6429). (Lack of such support is extremely rare, and such
+        # a case would tend to support setf rather than setaf.)
+        color_prompt=yes
     else
-	color_prompt=
+        color_prompt=
     fi
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Dotfiles setup script
+# Usage: ./setup.sh
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "==> Installing packages..."
+"$REPO_DIR/install/ubuntu/packages.sh"
+
+echo "==> Installing chezmoi..."
+"$REPO_DIR/install/common/chezmoi.sh"
+
+echo "==> Applying dotfiles..."
+chezmoi init --source="$REPO_DIR"
+chezmoi apply
+
+echo "Setup complete."


### PR DESCRIPTION
## Summary

- `setup.sh` を追加し、パッケージインストール・chezmoi インストール・dotfiles 適用を一括で実行できるようにした
- `home/.chezmoi.toml.tmpl` を追加し、chezmoi のソースディレクトリが常にこのリポジトリを指すように設定を永続化した

## Test plan

- [ ] クリーンな Ubuntu 環境で `./setup.sh` を実行し、エラーなく完了することを確認
- [ ] `setup.sh` 実行後に `chezmoi status` で差分がないことを確認
- [ ] 再度 `./setup.sh` を実行しても冪等に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)