### PR TITLE
feat: secretlint によるシークレット漏洩防止を導入

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,12 @@ jobs:
         run: |
           find . -name "*.sh" -type f | xargs shellcheck
 
+      - name: Install secretlint
+        run: npm install -g secretlint @secretlint/secretlint-rule-preset-recommend
+
+      - name: Run secretlint
+        run: secretlint --secretlintrc home/dot_secretlintrc.json "**/*"
+
   docker-test:
     name: Docker Integration Test
     runs-on: ubuntu-latest

--- a/home/dot_config/git/hooks/executable_pre-commit
+++ b/home/dot_config/git/hooks/executable_pre-commit
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v secretlint &>/dev/null; then
+  echo "secretlint is not installed. Skipping secret check."
+  exit 0
+fi
+
+# ステージングされたファイルに対してスキャン
+git diff --cached --name-only --diff-filter=ACM | xargs secretlint --secretlintrc ~/.secretlintrc.json

--- a/home/dot_gitconfig.tmpl
+++ b/home/dot_gitconfig.tmpl
@@ -11,6 +11,7 @@
 [core]
     editor = vim
     excludesfile = {{ .chezmoi.homeDir }}/.gitignore_global
+    hooksPath = ~/.config/git/hooks
 [credential "https://github.com"]
     helper =
     helper = !/usr/bin/gh auth git-credential

--- a/home/dot_secretlintrc.json
+++ b/home/dot_secretlintrc.json
@@ -1,0 +1,7 @@
+{
+  "rules": [
+    {
+      "id": "@secretlint/secretlint-rule-preset-recommend"
+    }
+  ]
+}

--- a/install/common/secretlint.sh
+++ b/install/common/secretlint.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v secretlint &>/dev/null; then
+  echo "secretlint is already installed. Skipping."
+  exit 0
+fi
+
+echo "Installing secretlint..."
+npm install -g secretlint @secretlint/secretlint-rule-preset-recommend

--- a/setup.sh
+++ b/setup.sh
@@ -12,6 +12,9 @@ echo "==> Installing packages..."
 echo "==> Installing chezmoi..."
 "$REPO_DIR/install/common/chezmoi.sh"
 
+echo "==> Installing secretlint..."
+bash "$(dirname "$0")/install/common/secretlint.sh"
+
 echo "==> Applying dotfiles..."
 chezmoi init --source="$REPO_DIR"
 chezmoi apply


### PR DESCRIPTION
## Summary

- `~/.secretlintrc.json` を chezmoi で一元管理し、推奨プリセットでシークレットを検出
- git pre-commit hook でコミット前にステージング済みファイルをスキャン
- `gitconfig` に `hooksPath` を追加して hook を自動適用
- `install/common/secretlint.sh` でグローバルインストール（冪等性あり）
- GitHub Actions の lint ジョブに secretlint スキャンを追加し、CI でも二重防御

## Test plan

- [ ] `chezmoi apply` を実行して `~/.secretlintrc.json` と `~/.config/git/hooks/pre-commit` が配置されることを確認
- [ ] ダミーシークレット（例: `AWS_SECRET_KEY=XXXX`）を含むファイルをステージングして pre-commit hook が失敗することを確認
- [ ] CI を push して GitHub Actions の secretlint ジョブが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)