### PR TITLE
feat: Nix パッケージマネージャーの導入

### DIFF
--- a/home/dot_bashrc
+++ b/home/dot_bashrc
@@ -148,4 +148,9 @@ export PATH="$PATH:$HOME/chezmoi/bin/"
 # opencode
 export PATH=/home/rito528/.opencode/bin:$PATH
 
+# Nix
+if [ -e /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+    . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+fi
+
 eval "$(starship init bash)"

--- a/install/common/nix.sh
+++ b/install/common/nix.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Install Nix package manager
+# Usage: ./install/common/nix.sh
+
+set -euo pipefail
+
+if command -v nix &>/dev/null; then
+    echo "Nix is already installed"
+    exit 0
+fi
+
+echo "Installing Nix (Determinate Systems installer)..."
+curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix \
+    | sh -s -- install --no-confirm
+
+echo "Nix installation complete."
+echo "Please restart your shell or run: . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh"

--- a/setup.sh
+++ b/setup.sh
@@ -14,6 +14,9 @@ REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 echo "==> Installing packages..."
 "$REPO_DIR/install/ubuntu/packages.sh"
 
+echo "==> Installing Nix..."
+"$REPO_DIR/install/common/nix.sh"
+
 echo "==> Installing chezmoi..."
 "$REPO_DIR/install/common/chezmoi.sh"
 


### PR DESCRIPTION
## Summary

- Determinate Systems インストーラーを使用した Nix の自動セットアップを追加
- `install/common/nix.sh` を新規作成（既インストール時はスキップする冪等性チェック付き）
- `setup.sh` に Nix インストールステップを追加（chezmoi の前に実行）
- `home/dot_bashrc` に Nix プロファイルの source 設定を追加

## Test plan

- [ ] `shellcheck install/common/nix.sh` でリント確認
- [ ] `bash install/common/nix.sh` を実行してインストール確認
- [ ] 2回目実行で "already installed" メッセージが出ることを確認（冪等性）
- [ ] `nix --version` で動作確認
- [ ] CI が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)