### PR TITLE
feat: パッケージ管理を Nix Flake (home-manager) に移行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,14 @@ jobs:
       - name: Run secretlint
         run: secretlint --secretlintrc home/dot_secretlintrc.json "**/*"
 
+  nix-flake-check:
+    name: Nix Flake Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/nix-installer-action@v16
+      - run: nix flake check --impure ./home/dot_config/home-manager
+
   docker-test:
     name: Docker Integration Test
     runs-on: ubuntu-latest

--- a/home/dot_bashrc
+++ b/home/dot_bashrc
@@ -125,7 +125,7 @@ switch-branch-with-refresh() {
 }
 
 export GPG_TTY=$(tty)
-eval "$(direnv hook bash)"
+command -v direnv &>/dev/null && eval "$(direnv hook bash)"
 alias delete-branches="git fetch -p && git branch --merged | grep -v '*' | xargs git branch -d"
 export GPG_TTY=$(tty)
 . "$HOME/.cargo/env"
@@ -153,4 +153,4 @@ if [ -e /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
     . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
 fi
 
-eval "$(starship init bash)"
+command -v starship &>/dev/null && eval "$(starship init bash)"

--- a/home/dot_config/home-manager/flake.nix
+++ b/home/dot_config/home-manager/flake.nix
@@ -1,0 +1,23 @@
+{
+  description = "Home Manager configuration";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { nixpkgs, home-manager, ... }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+      username = builtins.getEnv "USER";
+    in {
+      homeConfigurations.${username} = home-manager.lib.homeManagerConfiguration {
+        inherit pkgs;
+        modules = [ ./home.nix ];
+      };
+    };
+}

--- a/home/dot_config/home-manager/home.nix
+++ b/home/dot_config/home-manager/home.nix
@@ -1,0 +1,13 @@
+{ pkgs, ... }: {
+  home.username = builtins.getEnv "USER";
+  home.homeDirectory = builtins.getEnv "HOME";
+  home.stateVersion = "24.11";
+
+  home.packages = with pkgs; [
+    jq
+    direnv
+    starship
+  ];
+
+  programs.home-manager.enable = true;
+}

--- a/install/common/home-manager.sh
+++ b/install/common/home-manager.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Install packages via home-manager
+# Usage: ./install/common/home-manager.sh
+
+set -euo pipefail
+
+NIX_PROFILE=/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+if [ -e "$NIX_PROFILE" ] && ! command -v nix &>/dev/null; then
+    # shellcheck source=/dev/null
+    . "$NIX_PROFILE"
+fi
+
+FLAKE_PATH="$HOME/.config/home-manager"
+
+if command -v home-manager &>/dev/null; then
+    home-manager switch --flake "$FLAKE_PATH"
+else
+    nix run nixpkgs#home-manager -- switch --flake "$FLAKE_PATH" --impure
+fi

--- a/install/ubuntu/packages.sh
+++ b/install/ubuntu/packages.sh
@@ -9,8 +9,6 @@ PACKAGES=(
     curl
     wget
     gpg
-    jq
-    direnv
     build-essential
 )
 

--- a/setup.sh
+++ b/setup.sh
@@ -20,11 +20,11 @@ echo "==> Installing Nix..."
 echo "==> Installing chezmoi..."
 "$REPO_DIR/install/common/chezmoi.sh"
 
-echo "==> Installing secretlint..."
-bash "$(dirname "$0")/install/common/secretlint.sh"
-
 echo "==> Applying dotfiles..."
 chezmoi init --source="$REPO_DIR"
 chezmoi apply
+
+echo "==> Applying home-manager configuration..."
+"$REPO_DIR/install/common/home-manager.sh"
 
 echo "Setup complete."


### PR DESCRIPTION
## Summary

- `jq`・`direnv`・`starship` を apt/未管理から home-manager による宣言的管理に移行
- `install/common/home-manager.sh` を追加し、`setup.sh` の bootstrap 順序に組み込む
- secretlint のセットアップを `setup.sh` から除去（CI 専用のため）
- direnv/starship の shell hook を `command -v` ガード付きに変更し、未インストール時も安全に動作するよう改善
- CI に `nix-flake-check` ジョブを追加して flake の健全性を自動検証

## Test plan

- [ ] CI の `nix-flake-check` ジョブが通ること
- [ ] CI の既存 `lint` / `docker-test` ジョブが通ること
- [ ] ローカルで `setup.sh` を実行し、`jq --version`・`direnv version`・`starship --version` が確認できること
- [ ] `setup.sh` を再実行しても冪等に完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)