### PR TITLE
fix: ドライランで鍵ファイルが破壊されないよう activation script を修正

### DIFF
--- a/nix/modules/gpg.nix
+++ b/nix/modules/gpg.nix
@@ -19,12 +19,9 @@
     elif ! ${pkgs.doppler}/bin/doppler whoami &>/dev/null; then
       echo "WARNING: Doppler 未認証。'doppler login' 後に home-manager switch を再実行してください。"
     else
-      ${pkgs.doppler}/bin/doppler secrets get GPG_PUBKEY --plain --project keys --config prd \
-        | ${pkgs.gnupg}/bin/gpg --import
-      ${pkgs.doppler}/bin/doppler secrets get GPG_SUBKEYS --plain --project keys --config prd \
-        | ${pkgs.gnupg}/bin/gpg --import
-      ${pkgs.doppler}/bin/doppler secrets get GPG_OWNERTRUST --plain --project keys --config prd \
-        | ${pkgs.gnupg}/bin/gpg --import-ownertrust
+      $DRY_RUN_CMD bash -c "${pkgs.doppler}/bin/doppler secrets get GPG_PUBKEY --plain --project keys --config prd | ${pkgs.gnupg}/bin/gpg --import"
+      $DRY_RUN_CMD bash -c "${pkgs.doppler}/bin/doppler secrets get GPG_SUBKEYS --plain --project keys --config prd | ${pkgs.gnupg}/bin/gpg --import"
+      $DRY_RUN_CMD bash -c "${pkgs.doppler}/bin/doppler secrets get GPG_OWNERTRUST --plain --project keys --config prd | ${pkgs.gnupg}/bin/gpg --import-ownertrust"
     fi
   '';
 
@@ -34,10 +31,8 @@
     elif ! ${pkgs.doppler}/bin/doppler whoami &>/dev/null; then
       echo "WARNING: Doppler 未認証。'doppler login' 後に home-manager switch を再実行してください。"
     else
-      ${pkgs.doppler}/bin/doppler secrets get SSH_PRIVATE_KEY --plain --project keys --config prd \
-        > "$HOME/.ssh/id_rsa"
-      ${pkgs.doppler}/bin/doppler secrets get SSH_PUBLIC_KEY --plain --project keys --config prd \
-        > "$HOME/.ssh/id_rsa.pub"
+      $DRY_RUN_CMD bash -c "${pkgs.doppler}/bin/doppler secrets get SSH_PRIVATE_KEY --plain --project keys --config prd > \"$HOME/.ssh/id_rsa\""
+      $DRY_RUN_CMD bash -c "${pkgs.doppler}/bin/doppler secrets get SSH_PUBLIC_KEY --plain --project keys --config prd > \"$HOME/.ssh/id_rsa.pub\""
       $DRY_RUN_CMD chmod 600 "$HOME/.ssh/id_rsa"
       $DRY_RUN_CMD chmod 644 "$HOME/.ssh/id_rsa.pub"
     fi


### PR DESCRIPTION
## 概要

`home.activation` の `importSshKeys` および `importGpgKeys` において、Doppler からの取得処理が `$DRY_RUN_CMD` でラップされておらず、`home-manager build` などのドライラン実行時でもリダイレクト・パイプが評価され、既存の鍵ファイルが破壊される危険があった。

## 変更内容

- Doppler からの取得・書き込み・インポート処理全体を `$DRY_RUN_CMD bash -c "..."` でラップ
- ドライラン時はコマンド文字列の表示のみに留め、実際のファイル操作を防ぐ

## Test plan

- [ ] `home-manager build --flake ./nix --impure` が成功すること
- [ ] `nixfmt` フォーマット済みであること
- [ ] Docker build が成功すること (`docker build -f tests/Dockerfile .`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)