### PR TITLE
fix: nix-daemon の起動待機を sleep から polling ループに変更

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -28,5 +28,8 @@ ENV PATH="/nix/var/nix/profiles/default/bin:${PATH}"
 # 3. Run home-manager switch via actual script
 RUN . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && \
     sudo /nix/var/nix/profiles/default/bin/nix-daemon & \
-    sleep 3 && \
+    for i in $(seq 1 30); do \
+        nix store ping --store daemon 2>/dev/null && break; \
+        sleep 1; \
+    done && \
     bash /home/testuser/dotfiles/install/common/home-manager.sh


### PR DESCRIPTION
## Summary
- `tests/Dockerfile` で `sleep 3` による固定待機を行っていた箇所を、`nix store ping --store daemon` によるポーリングループに変更
- 最大30秒間、1秒おきに daemon の起動を確認し、起動済みであればすぐに次の処理へ進む

## Test plan
- [ ] `docker build -f tests/Dockerfile .` が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)