### PR TITLE
refactor: builtins.getEnv を廃止し named configuration に移行して Nix 評価を純粋化

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,8 @@
     "allow": [
       "Bash(chmod +x /home/rito528/programming/dotfiles/install/common/nix.sh)",
       "Bash(bash tests/test.sh 2>&1)",
-      "Bash(docker build:*)"
+      "Bash(docker build:*)",
+      "Bash(nixfmt:*)"
     ]
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           find nix -name "*.nix" -type f | \
             xargs nix run nixpkgs#nixfmt-rfc-style -- --check
-      - run: nix flake check --impure ./nix
+      - run: nix flake check ./nix
 
   docker-test:
     name: Docker Integration Test

--- a/install/common/home-manager.sh
+++ b/install/common/home-manager.sh
@@ -14,7 +14,7 @@ REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 FLAKE_PATH="$REPO_DIR/nix"
 
 if command -v home-manager &>/dev/null; then
-    home-manager switch --flake "$FLAKE_PATH" --impure -b backup
+    home-manager switch --flake "$FLAKE_PATH#${USER}" -b backup
 else
-    nix run nixpkgs#home-manager -- switch --flake "$FLAKE_PATH" --impure -b backup
+    nix run nixpkgs#home-manager -- switch --flake "$FLAKE_PATH#${USER}" -b backup
 fi

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -21,17 +21,20 @@
             "claude-code"
           ];
       };
-      username = builtins.getEnv "USER";
-      homeDirectory = builtins.getEnv "HOME";
+      mkHomeConfig =
+        username: homeDirectory:
+        home-manager.lib.homeManagerConfiguration {
+          inherit pkgs;
+          modules = [ ./home.nix ];
+          extraSpecialArgs = {
+            inherit username homeDirectory;
+          };
+        };
     in
     {
-      homeConfigurations.${username} = home-manager.lib.homeManagerConfiguration {
-        inherit pkgs;
-        modules = [ ./home.nix ];
-        extraSpecialArgs = {
-          username = username;
-          homeDirectory = homeDirectory;
-        };
+      homeConfigurations = {
+        "rito528" = mkHomeConfig "rito528" "/home/rito528";
+        "testuser" = mkHomeConfig "testuser" "/home/testuser";
       };
     };
 }

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1,4 +1,8 @@
-{ ... }:
+{
+  username,
+  homeDirectory,
+  ...
+}:
 {
   imports = [
     ./modules/packages.nix
@@ -9,8 +13,8 @@
     ./modules/secretlint.nix
   ];
 
-  home.username = builtins.getEnv "USER";
-  home.homeDirectory = builtins.getEnv "HOME";
+  home.username = username;
+  home.homeDirectory = homeDirectory;
   home.stateVersion = "24.11";
 
   programs.home-manager.enable = true;


### PR DESCRIPTION
## Summary

- `builtins.getEnv "USER"` / `"HOME"` を廃止し、`--impure` フラグへの依存を除去
- `mkHomeConfig` ヘルパーで `homeConfigurations."rito528"` と `"testuser"` (Docker CI 用) をハードコード定義
- `home-manager switch` を `--flake "$FLAKE_PATH#${USER}"` 形式に変更
- CI の `nix flake check` から `--impure` を削除

## Test plan

- [ ] `nix flake check ./nix` がエラーなく通ること
- [ ] `home-manager build --flake ./nix#rito528` が成功すること
- [ ] Docker build (`docker build -f tests/Dockerfile .`) が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)