### PR TITLE
ci: ドキュメントのみの変更では CI をスキップ

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,20 @@ name: CI
 on:
   push:
     branches: [main]
+    paths:
+      - 'nix/**'
+      - 'config/**'
+      - 'install/**'
+      - 'tests/**'
+      - '.github/workflows/**'
   pull_request:
     branches: [main]
+    paths:
+      - 'nix/**'
+      - 'config/**'
+      - 'install/**'
+      - 'tests/**'
+      - '.github/workflows/**'
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary

- `push`/`pull_request` トリガーに `paths` フィルターを追加
- `nix/`, `config/`, `install/`, `tests/`, `.github/workflows/` のいずれかが変更された場合のみ CI を実行
- README 等のドキュメントのみの変更では CI が不要に実行されなくなる

## Test plan

- [ ] ドキュメントのみを変更した PR/push で CI がスキップされることを確認
- [ ] `nix/` 配下のファイルを変更した PR/push で CI が実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)