### PR TITLE
fix: GitHub Actions の依存関係をSHAダイジェストでピン留めする

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "matchDepTypes": ["action"],
+      "pinDigests": true
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- Renovate の設定に `packageRules` を追加し、GitHub Actions の参照をSHAハッシュ形式にピン留めするよう設定
- サプライチェーン攻撃（タグの書き換えによる悪意あるコード混入）を防止

## Test plan

- [ ] Renovate が次回実行時に Actions の参照を SHA ダイジェスト形式に更新する PR を作成することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)