### PR TITLE
ci: flake.lock を週次で自動更新するワークフローを追加

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,22 @@
+name: Update flake.lock
+
+on:
+  schedule:
+    - cron: '0 0 * * 1'  # 毎週月曜日 UTC 0:00
+  workflow_dispatch:
+
+jobs:
+  update-flake-lock:
+    name: Update flake.lock
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/nix-installer-action@v21
+      - uses: DeterminateSystems/update-flake-lock@834c491b2ece4de0bbd00d85214bb5e83b4da5c6
+        with:
+          pr-title: 'chore: update flake.lock'
+          pr-labels: |
+            dependencies


### PR DESCRIPTION
## Summary
- `DeterminateSystems/update-flake-lock` アクションを使い、毎週月曜日に `flake.lock` を自動更新する GitHub Actions ワークフローを追加
- 更新があった場合は自動で PR を作成し、`dependencies` ラベルを付与する
- `workflow_dispatch` により手動実行も可能

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)