### PR TITLE
fix: update-flake-lock ワークフローの flake.lock パスを修正

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -20,3 +20,4 @@ jobs:
           pr-title: 'chore: update flake.lock'
           pr-labels: |
             dependencies
+          flake-lock-file-path: nix/flake.lock


### PR DESCRIPTION
## Summary
- `DeterminateSystems/update-flake-lock` アクションに `flake-lock-file-path: nix/flake.lock` を追加
- `flake.nix` が `nix/` サブディレクトリにあるため、デフォルト設定だとルートを探してエラーになっていた

## Test plan
- [ ] ワークフローを手動実行し、エラーなく完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)