### PR TITLE
feat: renovate による npm パッケージの自動バージョン更新を設定

### DIFF
--- a/.github/workflows/nix-update-pr.yml
+++ b/.github/workflows/nix-update-pr.yml
@@ -1,0 +1,41 @@
+name: Update nix hashes on Renovate PRs
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'nix/modules/npm/packages/*.nix'
+
+jobs:
+  update-hashes:
+    # Renovate が開いた PR のみ対象
+    if: startsWith(github.head_ref, 'renovate/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
+
+      - name: Update hashes for changed nix files
+        run: |
+          changed=$(git diff --name-only origin/main HEAD -- 'nix/modules/npm/packages/*.nix')
+          cd nix
+          for f in $changed; do
+            pkg=$(basename "$f" .nix)
+            version=$(grep 'version = ' "modules/npm/packages/${pkg}.nix" | head -1 | sed 's/.*version = "\(.*\)".*/\1/')
+            echo "Updating hashes for ${pkg} @ ${version}..."
+            nix run nixpkgs#nix-update -- --version="${version}" --flake "${pkg}"
+          done
+
+      - name: Commit updated hashes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add nix/modules/npm/packages/
+          git diff --staged --quiet || git commit -m "chore: update nix hashes for renovate bump"
+          git push

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -31,7 +31,21 @@
           };
         };
     in
+    let
+      npmPackagesDir = ./modules/npm/packages;
+      allFiles = builtins.readDir npmPackagesDir;
+      nixFiles = builtins.filter (name: builtins.match ".*\\.nix" name != null) (
+        builtins.attrNames allFiles
+      );
+      npmPackages = builtins.listToAttrs (
+        map (name: {
+          name = builtins.replaceStrings [ ".nix" ] [ "" ] name;
+          value = import (npmPackagesDir + "/${name}") { inherit pkgs; };
+        }) nixFiles
+      );
+    in
     {
+      packages.${system} = npmPackages;
       homeConfigurations = {
         "rito528" = mkHomeConfig "rito528" "/home/rito528";
         "testuser" = mkHomeConfig "testuser" "/home/testuser";

--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,17 @@
       "matchDepTypes": ["action"],
       "pinDigests": true
     }
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["^nix/modules/npm/packages/.+\\.nix$"],
+      "matchStrings": [
+        "version = \"(?<currentValue>[^\"]+)\";[\\s\\S]*?owner = \"(?<packageOwner>[^\"]+)\";\\s+repo = \"(?<packageName>[^\"]+)\";"
+      ],
+      "depNameTemplate": "{{{packageOwner}}}/{{{packageName}}}",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^v?(?<version>.*)$"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- `renovate.json` に `regexManagers` を追加し、`nix/modules/npm/packages/*.nix` 内の `version`/`owner`/`repo` を検出して GitHub Releases を監視するよう設定
- `nix/flake.nix` に `packages.x86_64-linux` 出力を追加し、`nix-update --flake` が各パッケージを参照できるようにする
- `.github/workflows/nix-update-pr.yml` を新規追加。Renovate が開いた PR に対して `nix-update` を実行し、`fetchFromGitHub` / `pnpmDeps` 両方のハッシュを自動再計算してコミットする

## Test plan

- [ ] Renovate の Dependency Dashboard issue で `difit` が検出されることを確認
- [ ] `difit.nix` の version を古いものに戻して Renovate PR が作成されることを確認
- [ ] Renovate PR に対してワークフローが起動し、ハッシュが更新されること確認
- [ ] `home-manager build --flake ./nix --impure` が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)