### PR TITLE
fix: renovate の depName 解決失敗を renovate コメントマーカー方式で修正

### DIFF
--- a/nix/modules/npm/packages/difit.nix
+++ b/nix/modules/npm/packages/difit.nix
@@ -1,5 +1,6 @@
 { pkgs }:
 let
+  # renovate: datasource=github-releases depName=yoshiko-pg/difit
   version = "3.1.15";
   src = pkgs.fetchFromGitHub {
     owner = "yoshiko-pg";

--- a/renovate.json
+++ b/renovate.json
@@ -13,10 +13,8 @@
     {
       "fileMatch": ["^nix/modules/npm/packages/.+\\.nix$"],
       "matchStrings": [
-        "version = \"(?<currentValue>[^\"]+)\";[\\s\\S]*?owner = \"(?<packageOwner>[^\"]+)\";\\s+repo = \"(?<packageName>[^\"]+)\";"
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\s+version = \"(?<currentValue>[^\"]+)\";"
       ],
-      "depNameTemplate": "{{{packageOwner}}}/{{{packageName}}}",
-      "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver",
       "extractVersionTemplate": "^v?(?<version>.*)$"
     }


### PR DESCRIPTION
## Summary

- `regexManagers` で `depNameTemplate` による `owner/repo` 結合が正しく機能せず、`depName` が `difit` のみになって Renovate が依存関係を解決できない問題を修正
- 各 `.nix` ファイルに `# renovate: datasource=... depName=...` コメントマーカーを付与し、シンプルな regex で `datasource` と `depName` を直接読み取る方式に変更
- `difit.nix` にコメントマーカーを追加（`yoshiko-pg/difit`）

## Test plan

- [ ] Renovate の Dependency Dashboard issue で `difit` (`yoshiko-pg/difit`) が正常に検出されることを確認
- [ ] Renovate が新バージョンの PR を作成できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)