### PR TITLE
fix: renovate npm パッケージ自動更新の不具合修正

### DIFF
--- a/.github/workflows/nix-update-pr.yml
+++ b/.github/workflows/nix-update-pr.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
 
       - uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
 


### PR DESCRIPTION
## Summary

- `depNameTemplate` による `owner/repo` 結合が機能せず Renovate が依存関係を解決できない問題を修正 → renovate コメントマーカー方式に変更
- `actions/checkout` が `origin/main` を取得しないため `git diff` が失敗する問題を修正 → `fetch-depth: 0` を追加

## Test plan

- [ ] Renovate Dependency Dashboard で `yoshiko-pg/difit` が正常に検出されることを確認
- [ ] Renovate PR の Actions が最後まで通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)