### PR TITLE
fix: nix-update に --version=skip を指定してハッシュのみ再計算する

### DIFF
--- a/.github/workflows/nix-update-pr.yml
+++ b/.github/workflows/nix-update-pr.yml
@@ -28,9 +28,8 @@ jobs:
           cd nix
           for f in $changed; do
             pkg=$(basename "$f" .nix)
-            version=$(grep 'version = ' "modules/npm/packages/${pkg}.nix" | head -1 | sed 's/.*version = "\(.*\)".*/\1/')
-            echo "Updating hashes for ${pkg} @ ${version}..."
-            nix run nixpkgs#nix-update -- --version="${version}" --flake "${pkg}"
+            echo "Updating hashes for ${pkg}..."
+            nix run nixpkgs#nix-update -- --version=skip --flake "${pkg}"
           done
 
       - name: Commit updated hashes


### PR DESCRIPTION
## Summary

- `--version=${version}` だとファイルのバージョンが既に最新と判断され「No changes detected」でスキップされる問題を修正
- `--version=skip` に変更することでバージョン変更なしにハッシュのみ再フェッチ・再計算するようになる

## Test plan

- [ ] Renovate PR の Actions で `nix-update` がハッシュを更新するコミットを作成することを確認
- [ ] `home-manager build` が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)