### PR TITLE
ci: renovate.json の設定ミスを CI で自動検出するジョブを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
       - 'install/**'
       - 'tests/**'
       - '.github/workflows/**'
+      - 'renovate.json'
   pull_request:
     branches: [main]
     paths:
@@ -17,6 +18,7 @@ on:
       - 'install/**'
       - 'tests/**'
       - '.github/workflows/**'
+      - 'renovate.json'
 
 jobs:
   lint:
@@ -60,3 +62,14 @@ jobs:
       - name: Build and test in Docker
         run: |
           docker build -t dotfiles-test -f tests/Dockerfile .
+
+  renovate-config-check:
+    name: Renovate Config Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Dry-run Renovate with local platform
+        run: npx --yes renovate --platform=local --dry-run=full
+        env:
+          LOG_LEVEL: debug


### PR DESCRIPTION
## Summary

- `.github/workflows/ci.yml` に `renovate-config-check` ジョブを追加
- `renovate.json` を `on.push.paths` / `on.pull_request.paths` のトリガーに追加
- `npx renovate --platform=local --dry-run=full` による dry run で設定の妥当性を検証

## 背景

`renovate.json` の設定ミスは Renovate が正しく動作しなくなる原因になるが、これまで CI では検証されていなかった。`--platform=local` はローカルファイルシステムを読んで依存関係の抽出・解決シミュレーションを行うため、JSON スキーマ検証のみより実態に近い検証ができる。GitHub トークン不要。

## Test plan

- [ ] `renovate.json` の `extends` に存在しないプリセットを追加した状態で PR → CI 失敗を確認
- [ ] 正常な `renovate.json` で CI が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

close #57