### PR TITLE
fix: notify.sh に実行権限を付与して Claude フックが動作するよう修正

### DIFF
--- a/nix/modules/claude.nix
+++ b/nix/modules/claude.nix
@@ -1,12 +1,14 @@
 { ... }:
 {
-  home.file.".claude" = {
-    source = ../../config/claude;
+  home.file.".claude/settings.json".source = ../../config/claude/settings.json;
+
+  home.file.".claude/skills" = {
+    source = ../../config/claude/skills;
     recursive = true;
   };
 
   home.file.".claude/hooks/notify.sh" = {
-    source = ../../config/claude/hooks/notify.sh;
+    text = builtins.readFile ../../config/claude/hooks/notify.sh;
     executable = true;
   };
 }


### PR DESCRIPTION
## Summary

- `home.file` の `recursive = true` でディレクトリをコピーした場合、Nix store 内のファイルは実行権限なし (`r--r--r--`) になる
- `~/.claude/hooks/notify.sh` が実行できず、Claude Code の Notification フックが動作しない問題を修正
- `notify.sh` を個別エントリで `executable = true` を指定することで実行権限を付与

## Test plan

- [ ] `home-manager switch` 後に `ls -la ~/.claude/hooks/notify.sh` で実行権限 (`rwxr-xr-x`) が付いていることを確認
- [ ] Claude Code の通知フックが動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)