### PR TITLE
refactor(nix): SSH 設定を gpg.nix から ssh.nix に分離

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -8,6 +8,7 @@
     ./modules/packages.nix
     ./modules/git.nix
     ./modules/gpg.nix
+    ./modules/ssh.nix
     ./modules/shell.nix
     ./modules/scripts
     ./modules/claude.nix

--- a/nix/modules/gpg.nix
+++ b/nix/modules/gpg.nix
@@ -8,12 +8,7 @@
     extraConfig = "allow-loopback-pinentry";
   };
 
-  home.activation.setupSshDirectory = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-    $DRY_RUN_CMD mkdir -p "$HOME/.ssh"
-    $DRY_RUN_CMD chmod 700 "$HOME/.ssh"
-  '';
-
-  home.activation.importGpgKeys = lib.hm.dag.entryAfter [ "setupSshDirectory" ] ''
+  home.activation.importGpgKeys = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     if [ "${"CI:-"}" = "true" ]; then
       $VERBOSE_ECHO "CI: GPG key import skipped"
     elif ! ${pkgs.doppler}/bin/doppler whoami &>/dev/null; then
@@ -22,19 +17,6 @@
       $DRY_RUN_CMD bash -c "${pkgs.doppler}/bin/doppler secrets get GPG_PUBKEY --plain --project keys --config prd | ${pkgs.gnupg}/bin/gpg --import"
       $DRY_RUN_CMD bash -c "${pkgs.doppler}/bin/doppler secrets get GPG_SUBKEYS --plain --project keys --config prd | ${pkgs.gnupg}/bin/gpg --import"
       $DRY_RUN_CMD bash -c "${pkgs.doppler}/bin/doppler secrets get GPG_OWNERTRUST --plain --project keys --config prd | ${pkgs.gnupg}/bin/gpg --import-ownertrust"
-    fi
-  '';
-
-  home.activation.importSshKeys = lib.hm.dag.entryAfter [ "setupSshDirectory" ] ''
-    if [ "${"CI:-"}" = "true" ]; then
-      $VERBOSE_ECHO "CI: SSH key import skipped"
-    elif ! ${pkgs.doppler}/bin/doppler whoami &>/dev/null; then
-      echo "WARNING: Doppler 未認証。'doppler login' 後に home-manager switch を再実行してください。"
-    else
-      $DRY_RUN_CMD bash -c "${pkgs.doppler}/bin/doppler secrets get SSH_PRIVATE_KEY --plain --project keys --config prd > \"$HOME/.ssh/id_rsa\""
-      $DRY_RUN_CMD bash -c "${pkgs.doppler}/bin/doppler secrets get SSH_PUBLIC_KEY --plain --project keys --config prd > \"$HOME/.ssh/id_rsa.pub\""
-      $DRY_RUN_CMD chmod 600 "$HOME/.ssh/id_rsa"
-      $DRY_RUN_CMD chmod 644 "$HOME/.ssh/id_rsa.pub"
     fi
   '';
 }

--- a/nix/modules/ssh.nix
+++ b/nix/modules/ssh.nix
@@ -1,0 +1,20 @@
+{ pkgs, lib, ... }:
+{
+  home.activation.setupSshDirectory = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    $DRY_RUN_CMD mkdir -p "$HOME/.ssh"
+    $DRY_RUN_CMD chmod 700 "$HOME/.ssh"
+  '';
+
+  home.activation.importSshKeys = lib.hm.dag.entryAfter [ "setupSshDirectory" ] ''
+    if [ "${"CI:-"}" = "true" ]; then
+      $VERBOSE_ECHO "CI: SSH key import skipped"
+    elif ! ${pkgs.doppler}/bin/doppler whoami &>/dev/null; then
+      echo "WARNING: Doppler 未認証。'doppler login' 後に home-manager switch を再実行してください。"
+    else
+      $DRY_RUN_CMD bash -c "${pkgs.doppler}/bin/doppler secrets get SSH_PRIVATE_KEY --plain --project keys --config prd > \"$HOME/.ssh/id_rsa\""
+      $DRY_RUN_CMD bash -c "${pkgs.doppler}/bin/doppler secrets get SSH_PUBLIC_KEY --plain --project keys --config prd > \"$HOME/.ssh/id_rsa.pub\""
+      $DRY_RUN_CMD chmod 600 "$HOME/.ssh/id_rsa"
+      $DRY_RUN_CMD chmod 644 "$HOME/.ssh/id_rsa.pub"
+    fi
+  '';
+}


### PR DESCRIPTION
## Summary

- `gpg.nix` に含まれていた SSH ディレクトリのセットアップ・SSH キーインポートは GPG と無関係な責務であるため、独立した `ssh.nix` モジュールに切り出した
- `gpg.nix` の `importGpgKeys` は `setupSshDirectory` への依存をなくし、`writeBoundary` に直接依存するよう変更

## Test plan

- [ ] `home-manager build --flake ./nix#testuser` が CI でパスすること
- [ ] `home-manager switch` 後に GPG・SSH キーが正常にインポートされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)