### PR TITLE
refactor(gpg): home-manager の Bash 統合に GPG_TTY 設定を委譲

### DIFF
--- a/nix/modules/gpg.nix
+++ b/nix/modules/gpg.nix
@@ -4,6 +4,7 @@
 
   services.gpg-agent = {
     enable = true;
+    enableBashIntegration = true;
     pinentry.package = pkgs.pinentry-curses;
     extraConfig = "allow-loopback-pinentry";
   };

--- a/nix/modules/shell.nix
+++ b/nix/modules/shell.nix
@@ -39,9 +39,6 @@
         fi
       fi
 
-      # GPG
-      export GPG_TTY=$(tty)
-
       # Nix daemon
       if [ -e /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
           . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh


### PR DESCRIPTION
## Summary

- `services.gpg-agent.enableBashIntegration = true` を有効化し、home-manager が GPG のシェル統合を自動注入するようにした
- `shell.nix` に手書きしていた `export GPG_TTY=$(tty)` を削除

## Test plan

- [ ] `nixfmt` フォーマット確認済み
- [ ] `home-manager build --flake ./nix#testuser` でビルド成功確認済み
- [ ] `home-manager switch` 後、`echo $GPG_TTY` で値が設定されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)