### PR TITLE
feat(nix): home-manager switch 時に古い generation を自動削除する

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   username,
   homeDirectory,
   ...
@@ -21,4 +22,9 @@
   home.stateVersion = "24.11";
 
   programs.home-manager.enable = true;
+
+  # 5日より古い generation を自動削除
+  home.activation.collectGarbage = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    $DRY_RUN_CMD nix-collect-garbage --delete-older-than 5d || true
+  '';
 }


### PR DESCRIPTION
## Summary

- `home.activation` に `nix-collect-garbage --delete-older-than 5d` を追加
- `home-manager switch` のたびに 5日より古い generation が自動削除されるようになった
- `lib.hm.dag.entryAfter ["writeBoundary"]` でファイル配置完了後に実行
- `$DRY_RUN_CMD` 対応・`|| true` でエラー時も switch は続行

## Test plan

- [ ] `home-manager switch` を実行してエラーなく完了することを確認
- [ ] 5日より古い generation がある場合、削除されることを確認
- [ ] `home-manager switch --dry-run` でスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)