### PR TITLE
fix: actrun.nix を Renovate の追跡対象に追加

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,8 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/^nix/modules/npm/packages/.+\\.nix$/"
+        "/^nix/modules/npm/packages/.+\\.nix$/",
+        "/^nix/modules/.+\\.nix$/"
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\s+version = \"(?<currentValue>[^\"]+)\";"


### PR DESCRIPTION
## Summary

- `renovate.json` の `customManagers.managerFilePatterns` が `nix/modules/npm/packages/` 配下のみを対象としており、`nix/modules/actrun.nix` が Renovate に追跡されていなかった
- `nix/modules/` 配下の全 `.nix` ファイルもパターンに追加し、`actrun.nix` の `# renovate:` コメントが認識されるようにした

## Test plan

- [ ] Renovate が `nix/modules/actrun.nix` の `version` を検出することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)