### PR TITLE
fix: pnpm の非推奨属性を新しいトップレベル属性に移行

### DIFF
--- a/nix/modules/npm/packages/difit.nix
+++ b/nix/modules/npm/packages/difit.nix
@@ -20,6 +20,7 @@ pkgs.stdenv.mkDerivation {
   inherit version src;
   nativeBuildInputs = [
     pkgs.nodejs_22
+    pkgs.pnpm
     pkgs.pnpmConfigHook
     pkgs.makeWrapper
   ];


### PR DESCRIPTION
## Summary

- `pkgs.pnpm.fetchDeps` → `pkgs.fetchPnpmDeps` に変更
- `pkgs.pnpm.configHook` → `pkgs.pnpmConfigHook` に変更

evaluation warning として出ていた非推奨警告を解消する。

## Test plan

- [ ] `home-manager build --flake ./nix#testuser` が警告なしで通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)