### PR TITLE
fix: Doppler 障害時に既存の鍵が上書きされるリスクを排除

### DIFF
--- a/nix/modules/gpg.nix
+++ b/nix/modules/gpg.nix
@@ -12,6 +12,8 @@
   home.activation.importGpgKeys = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     if [ "${"CI:-"}" = "true" ]; then
       $VERBOSE_ECHO "CI: GPG key import skipped"
+    elif ${pkgs.gnupg}/bin/gpg --list-secret-keys 2>/dev/null | grep -q '^sec'; then
+      $VERBOSE_ECHO "GPG secret key already exists, skipping import"
     elif ! ${pkgs.doppler}/bin/doppler whoami &>/dev/null; then
       echo "WARNING: Doppler 未認証。'doppler login' 後に home-manager switch を再実行してください。"
     else

--- a/nix/modules/ssh.nix
+++ b/nix/modules/ssh.nix
@@ -8,6 +8,8 @@
   home.activation.importSshKeys = lib.hm.dag.entryAfter [ "setupSshDirectory" ] ''
     if [ "${"CI:-"}" = "true" ]; then
       $VERBOSE_ECHO "CI: SSH key import skipped"
+    elif [ -f "$HOME/.ssh/id_rsa" ]; then
+      $VERBOSE_ECHO "SSH key already exists, skipping import"
     elif ! ${pkgs.doppler}/bin/doppler whoami &>/dev/null; then
       echo "WARNING: Doppler 未認証。'doppler login' 後に home-manager switch を再実行してください。"
     else


### PR DESCRIPTION
## Summary

- `gpg.nix`: `gpg --list-secret-keys` で秘密鍵が存在する場合、Doppler からのインポートをスキップ
- `ssh.nix`: `~/.ssh/id_rsa` が存在する場合、Doppler からのインポートをスキップ
- Doppler がダウン・未認証状態で `home-manager switch` を実行した際に既存の鍵が空データで上書きされるリスクを排除

## Test plan

- [ ] `nixfmt` フォーマット確認済み
- [ ] CI (`home-manager build`) が通ること
- [ ] 鍵が存在する環境で `home-manager switch` を実行し "already exists" メッセージが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)