### PR TITLE
fix: パッケージ管理を nix に一元化する

### DIFF
--- a/install/ubuntu/packages.sh
+++ b/install/ubuntu/packages.sh
@@ -5,10 +5,7 @@
 set -euo pipefail
 
 PACKAGES=(
-    git
     curl
-    wget
-    build-essential
 )
 
 echo "Updating package list..."

--- a/nix/modules/packages.nix
+++ b/nix/modules/packages.nix
@@ -1,6 +1,7 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
+    git
     jq
     direnv
     starship


### PR DESCRIPTION
## Summary

- `nix/modules/packages.nix` に `git` を追加し、nix で管理するように変更
- `install/ubuntu/packages.sh` から `git`/`wget`/`build-essential` を削除し、nix インストーラー実行に必要な `curl` のみを残す

## Background

setup 時は GitHub から zip でダウンロードし、nix によって `git` がインストールされてから remote を追加する方針に合わせた対応。
apt で管理するパッケージを最小限にし、パッケージ管理を nix に一元化する。

## Test plan

- [ ] `home-manager build --flake ./nix#testuser` が通ること (CI)
- [ ] nixfmt・shellcheck が通ること (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)