### PR TITLE
fix: shebang を持つ拡張子なしシェルスクリプトも shellcheck の対象に含める

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,4 +33,6 @@ jobs:
 
       - name: Run shellcheck
         run: |
-          find . -name "*.sh" -type f | xargs shellcheck
+          find . -type f \( -name "*.sh" -o ! -name "*.*" \) \
+            | xargs grep -lE '^#!.*\b(bash|sh)\b' \
+            | xargs shellcheck


### PR DESCRIPTION
## Summary

- `find . -name "*.sh"` のみを対象にしていたため、`config/git/hooks/pre-commit` のような拡張子なしのシェルスクリプトが shellcheck の検査から漏れていた
- `find` で拡張子なしファイルも候補に含め、`grep` で `bash`/`sh` の shebang を持つファイルのみに絞り込むことで対象を拡張した

## Test plan

- [ ] CI の shellcheck ステップが `config/git/hooks/pre-commit` を検査対象として処理することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)