### PR TITLE
fix: home-manager の世代管理を件数と日数の OR 条件に変更

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -24,8 +24,9 @@
 
   programs.home-manager.enable = true;
 
-  # 5日より古い generation を自動削除
+  # 3件超または5日より古い generation を自動削除
   home.activation.collectGarbage = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    $DRY_RUN_CMD nix-env --profile ~/.local/state/nix/profiles/home-manager --delete-generations +3 || true
     $DRY_RUN_CMD nix-collect-garbage --delete-older-than 5d || true
   '';
 }


### PR DESCRIPTION
## Summary

- 日数のみ (`--delete-older-than 5d`) だった世代削除に、件数条件 (`+3`) を追加
- 最新3件を超える世代、または5日より古い世代を削除するよう変更 (OR 条件)
- `nix-env --delete-generations +3` で世代リンクを削除後、`nix-collect-garbage` でストアパスを回収

## Test plan

- [ ] `home-manager switch` を複数回実行し、世代が3件以下に保たれることを確認
- [ ] 5日より古い世代が存在する場合に削除されることを確認
- [ ] CI (nixfmt / shellcheck / home-manager build) がパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)