### PR TITLE
fix: dev-* エイリアスに --refresh を追加

### DIFF
--- a/nix/modules/shell.nix
+++ b/nix/modules/shell.nix
@@ -22,9 +22,9 @@
       egrep = "egrep --color=auto";
       alert = ''notify-send --urgency=low -i "$([ $? = 0 ] && echo terminal || echo error)" "$(history|tail -n1|sed -e 's/^\s*[0-9]\+\s*//;s/[;&|]\s*alert$//')"'';
       delete-branches = "git fetch -p && git branch --merged | grep -v '*' | xargs -r git branch -d";
-      dev-rust = "nix develop github:rito528/dotfiles?dir=nix#rust";
-      dev-scala = "nix develop github:rito528/dotfiles?dir=nix#scala";
-      dev-typescript = "nix develop github:rito528/dotfiles?dir=nix#typescript";
+      dev-rust = "nix develop --refresh github:rito528/dotfiles?dir=nix#rust";
+      dev-scala = "nix develop --refresh github:rito528/dotfiles?dir=nix#scala";
+      dev-typescript = "nix develop --refresh github:rito528/dotfiles?dir=nix#typescript";
     };
 
     initExtra = ''


### PR DESCRIPTION
## Summary

- `dev-rust` / `dev-scala` / `dev-typescript` エイリアスに `--refresh` を追加
- Nix のフレークキャッシュにより最新の devShell が参照されない問題を修正

## Test plan

- [ ] CI がパスすること
- [ ] マージ・`home-manager switch` 後、`dev-rust` 等で最新の devShell に入れること

🤖 Generated with [Claude Code](https://claude.com/claude-code)