### PR TITLE
fix: nix-update-pr ワークフローを nix/modules/*.nix にも対応

### DIFF
--- a/.github/workflows/nix-update-pr.yaml
+++ b/.github/workflows/nix-update-pr.yaml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'nix/modules/npm/packages/*.nix'
+      - 'nix/modules/*.nix'
 
 jobs:
   update-hashes:
@@ -24,7 +25,7 @@ jobs:
 
       - name: Update hashes for changed nix files
         run: |
-          changed=$(git diff --name-only origin/main HEAD -- 'nix/modules/npm/packages/*.nix')
+          changed=$(git diff --name-only origin/main HEAD -- 'nix/modules/npm/packages/*.nix' 'nix/modules/*.nix')
           cd nix
           for f in $changed; do
             pkg=$(basename "$f" .nix)
@@ -36,6 +37,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add nix/modules/npm/packages/
+          git add nix/modules/
           git diff --staged --quiet || git commit -m "chore: update nix hashes for renovate bump"
           git push


### PR DESCRIPTION
## Summary

- `paths` トリガーに `nix/modules/*.nix` を追加し、`actrun.nix` など npm 以外の Nix モジュールでも CI が起動するよう修正
- ハッシュ更新スクリプトの `git diff` 対象パスも同様に拡張
- `git add` を `nix/modules/` 全体に変更し、更新されたハッシュがコミットに含まれるよう修正

## Test plan

- [ ] Renovate が `nix/modules/actrun.nix` のバージョンを更新する PR を作成し、本ワークフローが起動してハッシュが自動更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)