### PR TITLE
refactor: actrun を汎用 packages ディレクトリに移動して nix-update 対応

### DIFF
--- a/.github/workflows/nix-update-pr.yaml
+++ b/.github/workflows/nix-update-pr.yaml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     paths:
       - 'nix/modules/npm/packages/*.nix'
-      - 'nix/modules/*.nix'
+      - 'nix/modules/packages/*.nix'
 
 jobs:
   update-hashes:
@@ -25,7 +25,7 @@ jobs:
 
       - name: Update hashes for changed nix files
         run: |
-          changed=$(git diff --name-only origin/main HEAD -- 'nix/modules/npm/packages/*.nix' 'nix/modules/*.nix')
+          changed=$(git diff --name-only origin/main HEAD -- 'nix/modules/npm/packages/*.nix' 'nix/modules/packages/*.nix')
           cd nix
           for f in $changed; do
             pkg=$(basename "$f" .nix)
@@ -37,6 +37,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add nix/modules/
+          git add nix/modules/npm/packages/ nix/modules/packages/
           git diff --staged --quiet || git commit -m "chore: update nix hashes for renovate bump"
           git push

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -46,20 +46,25 @@
         };
     in
     let
-      npmPackagesDir = ./modules/npm/packages;
-      allFiles = builtins.readDir npmPackagesDir;
-      nixFiles = builtins.filter (name: builtins.match ".*\\.nix" name != null) (
-        builtins.attrNames allFiles
-      );
-      npmPackages = builtins.listToAttrs (
-        map (name: {
-          name = builtins.replaceStrings [ ".nix" ] [ "" ] name;
-          value = import (npmPackagesDir + "/${name}") { inherit pkgs; };
-        }) nixFiles
-      );
+      loadPackagesDir =
+        dir:
+        let
+          allFiles = builtins.readDir dir;
+          nixFiles = builtins.filter (name: name != "default.nix" && builtins.match ".*\\.nix" name != null) (
+            builtins.attrNames allFiles
+          );
+        in
+        builtins.listToAttrs (
+          map (name: {
+            name = builtins.replaceStrings [ ".nix" ] [ "" ] name;
+            value = import (dir + "/${name}") { inherit pkgs; };
+          }) nixFiles
+        );
+      npmPackages = loadPackagesDir ./modules/npm/packages;
+      extraPackages = loadPackagesDir ./modules/packages;
     in
     {
-      packages.${system} = npmPackages;
+      packages.${system} = npmPackages // extraPackages;
       homeConfigurations = {
         "rito528" = mkHomeConfig "rito528" "/home/rito528";
         "testuser" = mkHomeConfig "testuser" "/home/testuser";

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -15,7 +15,7 @@
     ./modules/claude.nix
     ./modules/gitleaks.nix
     ./modules/npm
-    ./modules/actrun.nix
+    ./modules/packages
   ];
 
   home.username = username;

--- a/nix/modules/packages/actrun.nix
+++ b/nix/modules/packages/actrun.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs }:
 let
   # renovate: datasource=github-releases depName=mizchi/actrun
   version = "0.3.0";
@@ -6,17 +6,14 @@ let
     url = "https://github.com/mizchi/actrun/releases/download/v${version}/actrun-linux-x64.tar.gz";
     hash = "sha256-Ine7JXdGT5+FgJYqRQHjLGf684eDP8zbKqaq3nf4XMI=";
   };
-  actrun = pkgs.stdenv.mkDerivation {
-    pname = "actrun";
-    inherit version src;
-    dontUnpack = true;
-    installPhase = ''
-      mkdir -p $out/bin
-      tar xzf $src -C $out/bin
-      chmod +x $out/bin/actrun
-    '';
-  };
 in
-{
-  home.packages = [ actrun ];
+pkgs.stdenv.mkDerivation {
+  pname = "actrun";
+  inherit version src;
+  dontUnpack = true;
+  installPhase = ''
+    mkdir -p $out/bin
+    tar xzf $src -C $out/bin
+    chmod +x $out/bin/actrun
+  '';
 }

--- a/nix/modules/packages/default.nix
+++ b/nix/modules/packages/default.nix
@@ -1,0 +1,11 @@
+{ pkgs, ... }:
+let
+  allFiles = builtins.readDir ./.;
+  nixFiles = builtins.filter (name: name != "default.nix" && builtins.match ".*\\.nix" name != null) (
+    builtins.attrNames allFiles
+  );
+  packages = map (name: import (./${name}) { inherit pkgs; }) nixFiles;
+in
+{
+  home.packages = packages;
+}

--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,7 @@
       "customType": "regex",
       "managerFilePatterns": [
         "/^nix/modules/npm/packages/.+\\.nix$/",
-        "/^nix/modules/.+\\.nix$/"
+        "/^nix/modules/packages/.+\\.nix$/"
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\s+version = \"(?<currentValue>[^\"]+)\";"


### PR DESCRIPTION
## Summary

- `nix/modules/actrun.nix` はモジュール形式のため flake `packages` outputs に expose されず、`nix-update --flake "actrun"` が失敗していた
- `nix/modules/packages/` を新設し、`actrun.nix` を derivation を直接返す形式に変更することで `nix-update` が正しく動作するようにした
- `nix/flake.nix` に `loadPackagesDir` ヘルパーを追加し、`modules/packages/*.nix` も自動で `packages.${system}` に expose
- Renovate の `managerFilePatterns` と `nix-update-pr` ワークフローのパスフィルターを新ディレクトリに合わせて更新

## Test plan

- [ ] `nix flake check` が通ること
- [ ] `home-manager build --flake ./nix#testuser` が通ること
- [ ] CI (lint / integration-test) がすべてパスすること
- [ ] Renovate が actrun のバージョンを上げる PR を開いた際、`nix-update-pr` ワークフローが正常にハッシュを更新してコミットすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)