### PR TITLE
fix: pre-compiled バイナリが libstdc++ を見つけられるよう LD_LIBRARY_PATH を設定

### DIFF
--- a/nix/modules/shell.nix
+++ b/nix/modules/shell.nix
@@ -1,5 +1,8 @@
-{ ... }:
+{ pkgs, ... }:
 {
+  home.sessionVariables = {
+    LD_LIBRARY_PATH = "${pkgs.stdenv.cc.cc.lib}/lib\${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}";
+  };
   programs.bash = {
     enable = true;
 


### PR DESCRIPTION
## Summary

- Nix on Ubuntu (non-NixOS) 環境で、protocbridge 等がダウンロードする pre-compiled バイナリが `libstdc++.so.6` を見つけられず起動失敗する問題を修正
- `pkgs.stdenv.cc.cc.lib` を `LD_LIBRARY_PATH` に追加し、protoc などのネイティブバイナリが共有ライブラリを解決できるようにした

## Test plan

- [ ] `home-manager switch` が成功すること
- [ ] 新しいシェルで `echo $LD_LIBRARY_PATH` に `libstdc++` のパスが含まれていること
- [ ] `sbt compile` で protobuf コンパイルが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)