### PR TITLE
feat: 公式手順に基づく Docker インストールスクリプトを追加

### DIFF
--- a/install/ubuntu/docker.sh
+++ b/install/ubuntu/docker.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Install Docker Engine on Ubuntu (official method)
+# https://docs.docker.com/engine/install/ubuntu/
+# Usage: ./install/ubuntu/docker.sh
+
+set -euo pipefail
+
+if dpkg -l docker-ce &>/dev/null; then
+    echo "Docker is already installed"
+else
+    echo "Setting up Docker apt repository..."
+    sudo apt-get update
+    sudo apt-get install -y ca-certificates curl
+    sudo install -m 0755 -d /etc/apt/keyrings
+    sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+    sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+    # shellcheck source=/dev/null
+    . /etc/os-release
+    echo \
+        "Types: deb
+URIs: https://download.docker.com/linux/ubuntu
+Suites: ${UBUNTU_CODENAME:-${VERSION_CODENAME}}
+Components: stable
+Signed-By: /etc/apt/keyrings/docker.asc" \
+        | sudo tee /etc/apt/sources.list.d/docker.sources > /dev/null
+
+    sudo apt-get update
+
+    echo "Installing Docker Engine..."
+    sudo apt-get install -y \
+        docker-ce \
+        docker-ce-cli \
+        containerd.io \
+        docker-buildx-plugin \
+        docker-compose-plugin
+fi
+
+echo "Enabling Docker service..."
+sudo systemctl enable --now docker
+
+if ! groups "$USER" | grep -q '\bdocker\b'; then
+    echo "Adding $USER to docker group..."
+    sudo usermod -aG docker "$USER"
+    echo "NOTE: Re-login required for docker group to take effect."
+fi
+
+echo "Docker installation complete."

--- a/nix/modules/packages.nix
+++ b/nix/modules/packages.nix
@@ -12,7 +12,6 @@
     claude-code
     github-copilot-cli
     shellcheck
-    docker
     ghq
   ];
 }


### PR DESCRIPTION
## Summary

- `docker.io` (Ubuntu パッケージ) ではなく Docker 公式の apt リポジトリから `docker-ce` をインストールするスクリプト (`install/ubuntu/docker.sh`) を追加
- systemd への自動起動登録・docker グループへのユーザー追加も実施
- 冪等性あり（既にインストール済みの場合はスキップ）
- Nix の `pkgs.docker` を削除し、apt 管理に移行

## Test plan

- [ ] `./install/ubuntu/docker.sh` が正常に完了すること
- [ ] `sudo systemctl status docker` で Docker が起動していること
- [ ] 再ログイン後、`sudo` なしで `docker run hello-world` が動作すること
- [ ] 再実行しても冪等に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)