### PR TITLE
fix: scala devShell に LD_LIBRARY_PATH を設定し protoc が libstdc++ を見つけられるようにする

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -97,7 +97,11 @@
             pkgs.sbt
             pkgs.metals
             pkgs.scalafmt
+            pkgs.stdenv.cc.cc.lib
           ];
+          shellHook = ''
+            export LD_LIBRARY_PATH="${pkgs.stdenv.cc.cc.lib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+          '';
         };
         typescript = pkgs.mkShell {
           buildInputs = [


### PR DESCRIPTION
## Summary

- `nix develop .#scala`（`dev-scala` alias）で入った devShell 内では `home.sessionVariables` が適用されないため、`shellHook` で `stdenv.cc.cc.lib` を `LD_LIBRARY_PATH` に追加
- これにより `protocbridge` がダウンロードする pre-compiled `protoc` バイナリが `libstdc++.so.6` を見つけられるようになる

## Test plan

- [ ] `dev-scala` で devShell に入り直す
- [ ] `echo $LD_LIBRARY_PATH` に `libstdc++` のパスが含まれていること
- [ ] `./prepare-docker.sh` or `sbt compile` で protobuf コンパイルが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)