### PR TITLE
feat: Scala devShell に bloop を追加する

### DIFF
--- a/nix/templates/scala/flake.nix
+++ b/nix/templates/scala/flake.nix
@@ -14,6 +14,7 @@
         buildInputs = [
           pkgs.jdk17
           pkgs.sbt
+          pkgs.bloop
           pkgs.metals
           pkgs.scalafmt
         ];


### PR DESCRIPTION
## Summary

- Scala テンプレートの devShell に `pkgs.bloop` を追加

## Test plan

- [ ] `nix develop` で devShell に入り、`bloop` コマンドが使用できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)