### PR TITLE
fix: SSH 秘密鍵作成時の一時的な world-readable 状態を修正

### DIFF
--- a/nix/modules/ssh.nix
+++ b/nix/modules/ssh.nix
@@ -13,10 +13,8 @@
     elif ! ${pkgs.doppler}/bin/doppler whoami &>/dev/null; then
       echo "WARNING: Doppler 未認証。'doppler login' 後に home-manager switch を再実行してください。"
     else
-      $DRY_RUN_CMD bash -c "${pkgs.doppler}/bin/doppler secrets get SSH_PRIVATE_KEY --plain --project keys --config prd > \"$HOME/.ssh/id_rsa\""
-      $DRY_RUN_CMD bash -c "${pkgs.doppler}/bin/doppler secrets get SSH_PUBLIC_KEY --plain --project keys --config prd > \"$HOME/.ssh/id_rsa.pub\""
-      $DRY_RUN_CMD chmod 600 "$HOME/.ssh/id_rsa"
-      $DRY_RUN_CMD chmod 644 "$HOME/.ssh/id_rsa.pub"
+      $DRY_RUN_CMD bash -c "(umask 077 && ${pkgs.doppler}/bin/doppler secrets get SSH_PRIVATE_KEY --plain --project keys --config prd > \"$HOME/.ssh/id_rsa\")"
+      $DRY_RUN_CMD bash -c "(umask 133 && ${pkgs.doppler}/bin/doppler secrets get SSH_PUBLIC_KEY --plain --project keys --config prd > \"$HOME/.ssh/id_rsa.pub\")"
     fi
   '';
 }


### PR DESCRIPTION
## Summary

- `importSshKeys` activation script において、`>` リダイレクトでファイル作成後に `chmod` を実行する方法では、umask(022) によりファイルが一時的に 644 (world-readable) になる TOCTOU 的なウィンドウが存在していた
- サブシェル内で `umask` を設定することで、ファイル作成と同時に適切なパーミッションを付与し、秘密鍵が他プロセスから読み取れる瞬間をなくした
  - 秘密鍵 (`id_rsa`): `umask 077` → 600
  - 公開鍵 (`id_rsa.pub`): `umask 133` → 644

## Test plan

- [ ] `nixfmt nix/modules/ssh.nix` がパスすること
- [ ] CI の `home-manager build` がパスすること
- [ ] 実環境で `home-manager switch` 後、`stat ~/.ssh/id_rsa` が `600`、`stat ~/.ssh/id_rsa.pub` が `644` であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)