### PR TITLE
feat: ghq が常に SSH でクローンするように git URL 書き換え設定を追加

### DIFF
--- a/nix/modules/git.nix
+++ b/nix/modules/git.nix
@@ -33,6 +33,7 @@
         "!/usr/bin/gh auth git-credential"
       ];
       push.autoSetupRemote = true;
+      "url \"git@github.com:\"".insteadOf = "https://github.com/";
     };
   };
 


### PR DESCRIPTION
## Summary

- `git url.insteadOf` を使って `https://github.com/` を `git@github.com:` に書き換える設定を `git.nix` に追加
- これにより `ghq get` をはじめとした git 操作が常に SSH プロトコルを使用するようになる

## Test plan

- [ ] `home-manager switch --flake ./nix` を実行
- [ ] `git config --global url.git@github.com:.insteadOf` で設定が反映されているか確認
- [ ] `ghq get <任意のリポジトリ>` を実行して SSH でクローンされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)