### PR TITLE
ci: setup.sh の E2E テスト CI を追加

### DIFF
--- a/.github/workflows/e2e-setup-test.yaml
+++ b/.github/workflows/e2e-setup-test.yaml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CI: true
-      HM_FLAKE_USER: testuser
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -23,18 +22,29 @@ jobs:
           name: rito528-dotfiles
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
-      - name: Create testuser home directory
-        run: sudo mkdir -p /home/testuser && sudo chown runner:runner /home/testuser
+      - name: Create testuser
+        run: |
+          sudo useradd -m -s /bin/bash testuser
+          sudo mkdir -p /nix/var/nix/profiles/per-user/testuser
+          sudo chown testuser:testuser /nix/var/nix/profiles/per-user/testuser
+          # Allow testuser to use nix
+          echo "trusted-users = root runner testuser" | sudo tee -a /etc/nix/nix.conf
+          sudo systemctl restart nix-daemon || true
 
-      - name: Run setup.sh
-        run: ./setup.sh
+      - name: Copy repo to testuser home
+        run: |
+          sudo cp -r "$GITHUB_WORKSPACE" /home/testuser/dotfiles
+          sudo chown -R testuser:testuser /home/testuser/dotfiles
+
+      - name: Run setup.sh as testuser
+        run: sudo -u testuser -i bash -c "cd /home/testuser/dotfiles && CI=true ./setup.sh"
 
       - name: Verify managed packages
         run: |
-          /home/testuser/.nix-profile/bin/jq --version
-          /home/testuser/.nix-profile/bin/rg --version
-          /home/testuser/.nix-profile/bin/gh --version
-          /home/testuser/.nix-profile/bin/starship --version
+          sudo -u testuser /home/testuser/.nix-profile/bin/jq --version
+          sudo -u testuser /home/testuser/.nix-profile/bin/rg --version
+          sudo -u testuser /home/testuser/.nix-profile/bin/gh --version
+          sudo -u testuser /home/testuser/.nix-profile/bin/starship --version
 
       - name: Verify managed config files
         run: |


### PR DESCRIPTION
## Summary

- `setup.sh` を実際に実行して `home-manager switch` まで完了することを検証する E2E CI ワークフローを追加
- `testuser` を実際に作成して `sudo -u testuser` で実行することで、home-manager の USER チェックを通過させる
- `install/common/home-manager.sh` に `HM_FLAKE_USER` 環境変数によるフォールバック対応を追加（将来の柔軟性のため残置）

## Test plan

- [ ] Actions タブで `E2E Setup Test` ワークフローが起動することを確認
- [ ] 全ステップが green になること
- [ ] `workflow_dispatch` で手動実行できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)