### PR TITLE
fix(ci): testuser に NOPASSWD sudo 権限を付与して apt-get を通過させる

### DIFF
--- a/.github/workflows/e2e-setup-test.yaml
+++ b/.github/workflows/e2e-setup-test.yaml
@@ -25,6 +25,7 @@ jobs:
       - name: Create testuser
         run: |
           sudo useradd -m -s /bin/bash testuser
+          echo "testuser ALL=(ALL) NOPASSWD:ALL" | sudo tee /etc/sudoers.d/testuser
           sudo mkdir -p /nix/var/nix/profiles/per-user/testuser
           sudo chown testuser:testuser /nix/var/nix/profiles/per-user/testuser
           # Allow testuser to use nix


### PR DESCRIPTION
## Summary

- E2E CI で `testuser` が `sudo apt-get` を実行できずに落ちる問題を修正
- `/etc/sudoers.d/testuser` に `NOPASSWD:ALL` を追加することで解決

## Test plan

- [ ] `E2E Setup Test` ワークフローの `packages.sh` ステップが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)