### PR TITLE
fix(install): nix.sh の冪等チェックをバイナリパスでも確認するように修正

### DIFF
--- a/install/common/nix.sh
+++ b/install/common/nix.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-if command -v nix &>/dev/null; then
+if command -v nix &>/dev/null || [ -e /nix/var/nix/profiles/default/bin/nix ]; then
     echo "Nix is already installed"
     exit 0
 fi


### PR DESCRIPTION
## Summary

- `sudo -u testuser` 等で実行した際に `PATH` に `nix` が含まれない環境でも、`/nix/var/nix/profiles/default/bin/nix` の存在を確認してスキップするよう修正
- E2E CI で `cachix/install-nix-action` 後に `setup.sh` を実行すると nixbld ユーザーの UID 重複エラーで落ちていた問題を解消

## Test plan

- [ ] E2E Setup Test ワークフローの `nix.sh` ステップで "Nix is already installed" と表示されてスキップされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)