### PR TITLE
fix(ci): XDG_CONFIG_HOME を明示指定して runner のパスが参照されないようにする

### DIFF
--- a/.github/workflows/e2e-setup-test.yaml
+++ b/.github/workflows/e2e-setup-test.yaml
@@ -38,7 +38,7 @@ jobs:
           sudo chown -R testuser:testuser /home/testuser/dotfiles
 
       - name: Run setup.sh as testuser
-        run: sudo -u testuser env HOME=/home/testuser bash -c "cd /home/testuser/dotfiles && CI=true ./setup.sh"
+        run: sudo -u testuser env HOME=/home/testuser XDG_CONFIG_HOME=/home/testuser/.config bash -c "cd /home/testuser/dotfiles && CI=true ./setup.sh"
 
       - name: Verify managed packages
         run: |


### PR DESCRIPTION
## Summary

- `sudo -u testuser env HOME=...` で実行しても `XDG_CONFIG_HOME` が runner の値（`/home/runner/.config`）のまま引き継がれ、home-manager が Permission denied で落ちる問題を修正
- `XDG_CONFIG_HOME=/home/testuser/.config` を明示的に指定することで解消

## Test plan

- [ ] E2E Setup Test の `Run setup.sh as testuser` ステップが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)