### PR TITLE
fix(ci): Verify ステップで HOME/XDG_CONFIG_HOME を明示指定して gh が runner のパスを参照しないようにする

### DIFF
--- a/.github/workflows/e2e-setup-test.yaml
+++ b/.github/workflows/e2e-setup-test.yaml
@@ -42,10 +42,10 @@ jobs:
 
       - name: Verify managed packages
         run: |
-          sudo -u testuser /home/testuser/.nix-profile/bin/jq --version
-          sudo -u testuser /home/testuser/.nix-profile/bin/rg --version
-          sudo -u testuser /home/testuser/.nix-profile/bin/gh --version
-          sudo -u testuser /home/testuser/.nix-profile/bin/starship --version
+          sudo -u testuser env HOME=/home/testuser XDG_CONFIG_HOME=/home/testuser/.config /home/testuser/.nix-profile/bin/jq --version
+          sudo -u testuser env HOME=/home/testuser XDG_CONFIG_HOME=/home/testuser/.config /home/testuser/.nix-profile/bin/rg --version
+          sudo -u testuser env HOME=/home/testuser XDG_CONFIG_HOME=/home/testuser/.config /home/testuser/.nix-profile/bin/gh --version
+          sudo -u testuser env HOME=/home/testuser XDG_CONFIG_HOME=/home/testuser/.config /home/testuser/.nix-profile/bin/starship --version
 
       - name: Verify managed config files
         run: |


### PR DESCRIPTION
## Summary

- `sudo -u testuser` は `--login` なしでは環境変数をリセットしないため、`HOME` が `/home/runner` のままになっていた
- `gh --version` 実行時に `gh` が `/home/runner/.config/gh/config.yml` を読もうとして permission denied でクラッシュしていた
- Verify managed packages ステップの各コマンドに `HOME=/home/testuser XDG_CONFIG_HOME=/home/testuser/.config` を明示指定して修正

## Test plan

- [ ] E2E Setup Test ワークフローが正常に完了すること
- [ ] `gh --version` が permission denied エラーなく出力されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)