### PR TITLE
fix(ci): linkGeneration 前に GC が走ってマネージドファイルのストアパスが削除される問題を修正

### DIFF
--- a/.github/workflows/e2e-setup-test.yaml
+++ b/.github/workflows/e2e-setup-test.yaml
@@ -28,6 +28,8 @@ jobs:
           echo "testuser ALL=(ALL) NOPASSWD:ALL" | sudo tee /etc/sudoers.d/testuser
           sudo mkdir -p /nix/var/nix/profiles/per-user/testuser
           sudo chown testuser:testuser /nix/var/nix/profiles/per-user/testuser
+          sudo mkdir -p /nix/var/nix/gcroots/per-user/testuser
+          sudo chown testuser:testuser /nix/var/nix/gcroots/per-user/testuser
           # Allow testuser to use nix
           echo "trusted-users = root runner testuser" | sudo tee -a /etc/nix/nix.conf
           sudo systemctl restart nix-daemon || true

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -25,7 +25,8 @@
   programs.home-manager.enable = true;
 
   # 3件超または5日より古い generation を自動削除
-  home.activation.collectGarbage = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  # linkGeneration の後に実行することで、新 generation の GC ルートが確立されてから GC を走らせる
+  home.activation.collectGarbage = lib.hm.dag.entryAfter [ "linkGeneration" ] ''
     $DRY_RUN_CMD nix-env --profile ~/.local/state/nix/profiles/home-manager --delete-generations +3 || true
     $DRY_RUN_CMD nix-collect-garbage --delete-older-than 5d || true
   '';

--- a/nix/modules/gpg.nix
+++ b/nix/modules/gpg.nix
@@ -10,7 +10,7 @@
   };
 
   home.activation.importGpgKeys = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-    if [ "${"CI:-"}" = "true" ]; then
+    if [ "''${CI:-}" = "true" ]; then
       $VERBOSE_ECHO "CI: GPG key import skipped"
     elif ${pkgs.gnupg}/bin/gpg --list-secret-keys 2>/dev/null | grep -q '^sec'; then
       $VERBOSE_ECHO "GPG secret key already exists, skipping import"

--- a/nix/modules/ssh.nix
+++ b/nix/modules/ssh.nix
@@ -6,7 +6,7 @@
   '';
 
   home.activation.importSshKeys = lib.hm.dag.entryAfter [ "setupSshDirectory" ] ''
-    if [ "${"CI:-"}" = "true" ]; then
+    if [ "''${CI:-}" = "true" ]; then
       $VERBOSE_ECHO "CI: SSH key import skipped"
     elif [ -f "$HOME/.ssh/id_rsa" ]; then
       $VERBOSE_ECHO "SSH key already exists, skipping import"


### PR DESCRIPTION
## Summary

- `collectGarbage` activation が `writeBoundary` の後・`linkGeneration` の前に実行されることで、新 generation の GC ルートが未登録の状態で `nix-collect-garbage` が走り、`.bashrc` 等のシンボリックリンクターゲットのストアパスが削除されて壊れたリンクになっていた
- E2E CI の "Verify managed config files" ステップで `test -f /home/testuser/.bashrc` 等が失敗していた根本原因

## Changes

- **`nix/home.nix`**: `collectGarbage` の `entryAfter` を `writeBoundary` → `linkGeneration` に変更し、GC ルート確立後に GC を実行するようにした
- **`.github/workflows/e2e-setup-test.yaml`**: `/nix/var/nix/gcroots/per-user/testuser/` を作成・chown し、home-manager が GC ルートを登録できるようにした
- **`nix/modules/gpg.nix`, `nix/modules/ssh.nix`**: `${"CI:-"}` は Nix 文字列補間でリテラル `"CI:-"` に展開され常に false になっていたため `''${CI:-}` に修正

## Test plan

- [ ] E2E CI の "Verify managed config files" ステップが通ること
- [ ] "Verify managed packages" ステップが引き続き通ること
- [ ] integration-test (home-manager build) が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)