### PR TITLE
fix(difit): packages/ をコピーして noBrokenSymlinks エラーを修正

### DIFF
--- a/nix/modules/npm/packages/difit.nix
+++ b/nix/modules/npm/packages/difit.nix
@@ -30,8 +30,7 @@ pkgs.stdenv.mkDerivation {
   '';
   installPhase = ''
     mkdir -p $out/lib/difit $out/bin
-    cp -r dist node_modules package.json $out/lib/difit/
-    find $out/lib/difit/node_modules -xtype l -delete
+    cp -r dist node_modules package.json packages $out/lib/difit/
     makeWrapper ${pkgs.nodejs_22}/bin/node $out/bin/difit \
       --add-flags "$out/lib/difit/dist/cli/index.js"
   '';


### PR DESCRIPTION
## Summary

- pnpm の仮想ストアが `difit-vscode` シンボリックリンクを `packages/vscode` に向けているため、`packages/` を含めてコピーしないと `noBrokenSymlinks` チェックで失敗していた
- ダングリングシンボリックリンク削除 (`find ... -xtype l -delete`) を除去し、`node_modules` のシンボリックリンクをランタイムでも正常に解決できるようにした

## Test plan

- [ ] `home-manager build` が成功すること
- [ ] `difit` 起動後、ブラウザのページが正常に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)