### PR TITLE
fix(ci): E2E の git config 検証パスを ~/.gitconfig から ~/.config/git/config に修正

### DIFF
--- a/.github/workflows/e2e-setup-test.yaml
+++ b/.github/workflows/e2e-setup-test.yaml
@@ -51,5 +51,5 @@ jobs:
         run: |
           test -f /home/testuser/.bashrc
           test -f /home/testuser/.bash_profile
-          test -f /home/testuser/.gitconfig
+          test -f /home/testuser/.config/git/config
           test -f /home/testuser/.config/git/hooks/pre-commit


### PR DESCRIPTION
## Summary

- `programs.git` は `xdg.configFile` を使用するため、git の設定ファイルは `~/.gitconfig` ではなく `~/.config/git/config` に生成される
- E2E の「Verify managed config files」ステップで存在しない `~/.gitconfig` をチェックしていたため `test -f` が失敗していた
- 正しいパス `~/.config/git/config` に修正

## Test plan

- [ ] E2E Setup Test CI が「Verify managed config files」ステップで成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)