### PR TITLE
feat: create-pr スキルを追加する

### DIFF
--- a/config/claude/skills/create-pr/SKILL.md
+++ b/config/claude/skills/create-pr/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: create-pr
+description: GitHub に Pull Request を作成するスキル。ユーザーが「PRを作って」「プルリクエストを出して」「PR作成して」と言ったとき、またはコミット済みの変更をレビューに出したいときに使用する。
+---
+
+# PR 作成スキル
+
+現在の変更から GitHub Pull Request を作成する。未コミットの変更がある場合は git-commit スキルを使ってコミットしてから PR を作成する。
+
+## 前提条件
+
+- `gh` CLI が認証済みであること
+
+## 手順
+
+### 1. 現状の確認
+
+以下を並列で実行して状況を把握する:
+
+```bash
+git status
+git log --oneline -10
+git branch -vv
+```
+
+### 2. コミットされていない変更の処理
+
+未コミットの変更や未追跡のファイルがある場合は、git-commit スキル (`/git-commit`) を使ってコミットする。git-commit スキルがブランチの作成やコミットメッセージの作成を担当する。
+
+### 3. ブランチの確認
+
+現在のブランチがメインブランチ（main/master）の場合:
+- 変更内容から適切なブランチ名を自動生成する（例: `feat/add-pr-skill`, `fix/ci-path`）
+- ブランチを作成して切り替え、コミットを移動する
+
+### 4. 差分の分析
+
+メインブランチからの全変更を確認する:
+
+```bash
+git log main..HEAD --oneline
+git diff main...HEAD --stat
+```
+
+**すべてのコミット** を確認すること。最新コミットだけでなく、PR に含まれる全コミットの内容を把握してからタイトルと本文を作成する。
+
+### 5. PR タイトルと本文の作成
+
+#### タイトル
+- 70文字以内で簡潔に
+- 変更の目的がわかるように書く
+- 詳細はタイトルではなく本文に書く
+
+#### 本文のテンプレート
+
+```markdown
+## 概要
+<!-- 変更の目的と内容を箇条書き 1〜3 点 -->
+
+## テスト計画
+<!-- テストや検証の方法をチェックリストで記述 -->
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+### 6. push と PR 作成
+
+```bash
+# リモートに push（未 push の場合）
+git push -u origin HEAD
+
+# PR 作成（本文は HEREDOC で渡す）
+gh pr create --title "タイトル" --body "$(cat <<'EOF'
+## 概要
+- ...
+
+## テスト計画
+- [ ] ...
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+### 7. 完了報告
+
+作成した PR の URL をユーザーに伝える。


### PR DESCRIPTION
## 概要

- `/create-pr` スキルを追加し、PR 作成の手順を標準化した
- 未コミットの変更がある場合は `/git-commit` スキルと連携してコミットを先に行う
- ブランチ作成・push・PR 作成までを一貫して実行できる

## テスト計画

- [ ] `/create-pr` を実行して PR が正常に作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)