### PR TITLE
fix(ci): ubuntu-latest を ubuntu-24.04 に固定してビルドの再現性を確保する

### DIFF
--- a/.github/workflows/e2e-setup-test.yaml
+++ b/.github/workflows/e2e-setup-test.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   e2e-setup-test:
     name: E2E Setup Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       CI: true
 

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -19,7 +19,7 @@ on:
 jobs:
   integration-test:
     name: Integration Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/nix-update-pr.yaml
+++ b/.github/workflows/nix-update-pr.yaml
@@ -11,7 +11,7 @@ jobs:
   update-hashes:
     # Renovate が開いた PR のみ対象
     if: startsWith(github.head_ref, 'renovate/')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -15,7 +15,7 @@ on:
 jobs:
   nix-flake-check:
     name: Nix Flake Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -15,7 +15,7 @@ on:
 jobs:
   renovate-config-check:
     name: Renovate Config Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/update-flake-lock.yaml
+++ b/.github/workflows/update-flake-lock.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   update-flake-lock:
     name: Update flake.lock
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## 概要

- 全 GitHub Actions ワークフローの `runs-on: ubuntu-latest` を `runs-on: ubuntu-24.04` に変更
- `ubuntu-latest` は時期によって指すバージョンが変わるため、CI の再現性が低下する問題があった

close #122

## テスト計画

- [ ] CI (lint / integration-test / nix check) がすべてパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)