### PR TITLE
feat(packages): git-wt を導入する

### DIFF
--- a/nix/modules/packages/git-wt.nix
+++ b/nix/modules/packages/git-wt.nix
@@ -1,0 +1,19 @@
+{ pkgs }:
+let
+  # renovate: datasource=github-releases depName=k1LoW/git-wt
+  version = "0.25.0";
+  src = pkgs.fetchurl {
+    url = "https://github.com/k1LoW/git-wt/releases/download/v${version}/git-wt_v${version}_linux_amd64.tar.gz";
+    hash = "sha256-PSdAwi97Dd1GlCXTZWFmwWm9UzhoigVXLinROZ4alFo=";
+  };
+in
+pkgs.stdenv.mkDerivation {
+  pname = "git-wt";
+  inherit version src;
+  dontUnpack = true;
+  installPhase = ''
+    mkdir -p $out/bin
+    tar xzf $src -C $out/bin git-wt
+    chmod +x $out/bin/git-wt
+  '';
+}


### PR DESCRIPTION
## 概要

- git worktree の管理を効率化するために [k1LoW/git-wt](https://github.com/k1LoW/git-wt) を追加
- `nix/modules/packages/git-wt.nix` として GitHub Releases のバイナリを取得する derivation を作成
- Renovate による自動バージョンアップに対応

## テスト計画

- [ ] `home-manager build --flake ./nix#testuser` が成功すること（CI で確認）
- [ ] `git wt` コマンドが利用可能になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)