### PR TITLE
chore: update TypeScript template Node.js to v24

### DIFF
--- a/nix/templates/typescript/flake.nix
+++ b/nix/templates/typescript/flake.nix
@@ -12,7 +12,7 @@
     {
       devShells.${system}.default = pkgs.mkShell {
         buildInputs = [
-          pkgs.nodejs_22
+          pkgs.nodejs_24
           pkgs.pnpm
         ];
       };


### PR DESCRIPTION
## Summary

- TypeScript テンプレートの Node.js バージョンを v22 から v24 に更新

## Test plan

- [ ] `nix develop` で TypeScript テンプレートの devShell が正常に起動することを確認
- [ ] `node --version` で v24.x が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)