### PR TITLE
docs: 定義ファイルから導出可能な情報を README から削除する

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 - **パッケージ管理**: [Nix](https://nixos.org/) + home-manager
 - **シークレット管理**: [Doppler](https://www.doppler.com/) (GPG/SSH キーも含む)
 - **シェル**: Bash
-- **追加ツール**: starship, direnv, gitleaks, difit (npm), claude-code
 
 ## ディレクトリ構成
 
@@ -123,11 +122,9 @@ home-manager generations
 
 プロジェクトごとに独立した Nix 開発環境を提供するテンプレートを管理しています。
 
-| テンプレート | 内容 |
-|-------------|------|
-| `rust` | Rust stable toolchain + pkg-config + openssl |
-| `scala` | JDK 17 + sbt + metals + scalafmt |
-| `typescript` | Node.js 22 + pnpm |
+- `rust`
+- `scala`
+- `typescript`
 
 ### 自分のプロジェクトで使う場合
 


### PR DESCRIPTION
## 概要

- 追加ツール一覧（starship, direnv, gitleaks 等）はパッケージ定義ファイルから確認できるため削除
- 開発環境テンプレートの内容列も同様に削除し、テンプレート名のみの箇条書きに簡略化

## テスト計画

- [ ] README の表示内容に問題がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)