### PR TITLE
docs(skill): create-pr でブランチ切り替えに git switch を使うよう明記する

### DIFF
--- a/config/claude/skills/create-pr/SKILL.md
+++ b/config/claude/skills/create-pr/SKILL.md
@@ -32,6 +32,9 @@ git branch -vv
 現在のブランチがメインブランチ（main/master）の場合:
 - 変更内容から適切なブランチ名を自動生成する（例: `feat/add-pr-skill`, `fix/ci-path`）
 - ブランチを作成して切り替え、コミットを移動する
+- ブランチの切り替えには `git checkout` ではなく `git switch` を使用すること
+  - 新規ブランチ作成と切り替えは `git switch -c <branch-name>`
+  - 既存ブランチへの切り替えは `git switch <branch-name>`
 
 ### 4. 差分の分析
 


### PR DESCRIPTION
## 概要
- `create-pr` スキルの手順3に、ブランチ切り替えは `git switch` を使用するよう明記した
- `git-commit` スキルと統一した操作方法にするための変更

## テスト計画
- [ ] スキルの内容を読んで記述が正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)