### PR TITLE
feat(setup): setup.sh から Docker インストールを呼び出す

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -14,6 +14,9 @@ REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 echo "==> Installing packages..."
 "$REPO_DIR/install/ubuntu/packages.sh"
 
+echo "==> Installing Docker..."
+"$REPO_DIR/install/ubuntu/docker.sh"
+
 echo "==> Installing Nix..."
 "$REPO_DIR/install/common/nix.sh"
 


### PR DESCRIPTION
## 概要

- `docker.sh` が定義されていたが `setup.sh` から呼ばれておらず、セットアップ時に Docker が自動インストールされなかった
- `packages.sh` の直後に `docker.sh` を呼び出すステップを追加する

## テスト計画

- [ ] `setup.sh` を実行して Docker が正常にインストールされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)