### PR TITLE
fix(ci): GitHub App トークンで nix ハッシュ更新後に CI を再トリガーする

### DIFF
--- a/.github/workflows/nix-update-pr.yaml
+++ b/.github/workflows/nix-update-pr.yaml
@@ -15,10 +15,16 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v3
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21


### PR DESCRIPTION
## 概要

- `nix-update-pr.yaml` で `GITHUB_TOKEN` の代わりに GitHub App トークンを使用するよう変更
- `GITHUB_TOKEN` による push は `pull_request: synchronize` を発火しないため、CI が再実行されず automerge がブロックされる問題を修正

## 背景

`renovate.json` に automerge を設定した際（#150）、以下の問題があった：
1. Renovate PR → `nix-update-pr.yaml` がハッシュ更新コミットを push
2. `GITHUB_TOKEN` による push は CI を再トリガーしない
3. 新しい SHA に対して required status checks が未実行のまま → auto-merge がブロック

GitHub App トークンを使用することで push 後に CI が再トリガーされる。

## 前提条件

- Repository Variables: `APP_ID` に GitHub App の App ID を登録済み
- Repository Secrets: `APP_PRIVATE_KEY` に GitHub App の秘密鍵を登録済み

## テスト計画

- [ ] Renovate が nix パッケージ更新 PR を作成する
- [ ] `nix-update-pr.yaml` がハッシュ更新コミットを push する
- [ ] CI が再実行される
- [ ] CI 通過後に auto-merge される

🤖 Generated with [Claude Code](https://claude.com/claude-code)