### PR TITLE
fix(ci): GitHub App トークンで nix ハッシュ更新の CI 再トリガーと無限ループ防止

### DIFF
--- a/.github/workflows/nix-update-pr.yaml
+++ b/.github/workflows/nix-update-pr.yaml
@@ -9,8 +9,8 @@ on:
 
 jobs:
   update-hashes:
-    # Renovate が開いた PR のみ対象
-    if: startsWith(github.head_ref, 'renovate/')
+    # Renovate が開いた PR のみ対象・GitHub App による push は無限ループ防止のためスキップ
+    if: startsWith(github.head_ref, 'renovate/') && github.actor != 'rito528-dotfiles-bot[bot]'
     runs-on: ubuntu-24.04
     permissions:
       contents: write


### PR DESCRIPTION
## 概要

- `nix-update-pr.yaml` で `GITHUB_TOKEN` の代わりに GitHub App トークンを使用
- GitHub App bot が actor の場合はジョブをスキップし、無限ループを防止

## 背景

`renovate.json` に automerge を設定すると以下の問題があった：

1. `GITHUB_TOKEN` による push は `pull_request: synchronize` を発火しないため CI が再実行されず、required status checks が未実行のまま auto-merge がブロックされる
2. GitHub App トークンで push すると CI は再トリガーされるが、`nix-update-pr.yaml` 自身も再実行されて無限ループになる

`github.actor` で GitHub App bot を判別してスキップすることで両方を解決する。

## 前提条件

- Repository Variables: `APP_ID` に GitHub App の App ID を登録済み
- Repository Secrets: `APP_PRIVATE_KEY` に GitHub App の秘密鍵を登録済み

## テスト計画

- [ ] Renovate が nix パッケージ更新 PR を作成する
- [ ] `nix-update-pr.yaml` がハッシュ更新コミットを push する
- [ ] CI が再実行される（無限ループしない）
- [ ] CI 通過後に auto-merge される

🤖 Generated with [Claude Code](https://claude.com/claude-code)