### PR TITLE
fix(renovate): nix ハッシュ更新コミットを外部編集とみなさないよう修正

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "gitIgnoredAuthors": ["github-actions[bot]@users.noreply.github.com"],
   "automerge": true,
   "automergeType": "pr",
   "platformAutomerge": true,


### PR DESCRIPTION
## 概要

- `renovate.json` に `gitIgnoredAuthors` を追加
- `nix-update-pr.yaml` が `github-actions[bot]` としてコミットすると Renovate が PR を外部編集とみなして edit block をかけ automerge が動かなくなる問題を修正

## テスト計画

- [ ] Renovate が nix パッケージ更新 PR を作成する
- [ ] `nix-update-pr.yaml` がハッシュ更新コミットを push する
- [ ] Renovate が edit block をかけずに automerge が継続される
- [ ] CI 通過後に auto-merge される

🤖 Generated with [Claude Code](https://claude.com/claude-code)