### PR TITLE
feat(shell): zsh-autosuggestions を導入する

### DIFF
--- a/nix/modules/shell.nix
+++ b/nix/modules/shell.nix
@@ -30,7 +30,17 @@
       dev-typescript = "nix develop --refresh github:rito528/dotfiles?dir=nix#typescript";
     };
 
+    plugins = [
+      {
+        name = "zsh-autosuggestions";
+        src = pkgs.zsh-autosuggestions;
+        file = "share/zsh-autosuggestions/zsh-autosuggestions.zsh";
+      }
+    ];
+
     initContent = ''
+      ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE="fg=#888888"
+
       # Nix daemon
       if [ -e /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
           . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh


### PR DESCRIPTION
## 概要

- コマンド入力の補完候補をリアルタイムで表示する `zsh-autosuggestions` プラグインを追加
- `programs.zsh.plugins` で home-manager 経由で宣言的に管理
- 補完候補の表示色を `#888888` に設定

## テスト計画

- [ ] `nixfmt` フォーマット確認済み
- [ ] `home-manager build --flake ./nix#testuser` が正常完了することを確認
- [ ] `home-manager switch` 後、コマンド入力時に補完候補が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)