### PR TITLE
fix(shell): CI 環境での chsh PAM 認証失敗を修正する

### DIFF
--- a/install/common/chsh-zsh.sh
+++ b/install/common/chsh-zsh.sh
@@ -13,6 +13,6 @@ fi
 
 # ログインシェルの変更
 if [ "$SHELL" != "$ZSH_PATH" ]; then
-    chsh -s "$ZSH_PATH"
+    sudo chsh -s "$ZSH_PATH" "$USER"
     echo "==> Login shell changed to $ZSH_PATH (requires re-login)"
 fi


### PR DESCRIPTION
## 概要

- `chsh -s` はパスワードによる PAM 認証を要求するため、パスワード未設定の `testuser` で実行すると `Authentication failure` が発生していた
- `sudo chsh -s "$ZSH_PATH" "$USER"` に変更し、`NOPASSWD:ALL` 設定済みの CI 環境でもパスワードなしでログインシェルを変更できるようにした

## テスト計画

- [ ] E2E Setup Test (`e2e-setup-test.yaml`) が正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)