### PR TITLE
feat(shell): zsh-autosuggestions の補完候補を直前コマンド優先にする

### DIFF
--- a/nix/modules/shell.nix
+++ b/nix/modules/shell.nix
@@ -40,6 +40,7 @@
 
     initContent = ''
       ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE="fg=#888888"
+      ZSH_AUTOSUGGEST_STRATEGY=(match_prev_cmd)
 
       # Nix daemon
       if [ -e /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then


### PR DESCRIPTION
## 概要
- `ZSH_AUTOSUGGEST_STRATEGY=(match_prev_cmd)` を設定し、補完候補を直前に実行したコマンドの文脈を優先して提示するようにした

## テスト計画
- [ ] `home-manager switch` 後にシェルを再起動し、補完候補が直前コマンド優先で表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)