### PR TITLE
feat(shell): zsh-autosuggestions の補完候補を直前コマンド優先にする

### DIFF
--- a/nix/modules/shell.nix
+++ b/nix/modules/shell.nix
@@ -38,6 +38,13 @@
       }
     ];
 
+    profileExtra = ''
+      # Nix daemon
+      if [ -e /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+      fi
+    '';
+
     initContent = ''
       ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE="fg=#888888"
       ZSH_AUTOSUGGEST_STRATEGY=(match_prev_cmd)


### PR DESCRIPTION
## 概要
- `ZSH_AUTOSUGGEST_STRATEGY=(match_prev_cmd)` を設定し、補完候補を直前コマンドのヒストリから優先的に選択するようにした
- `programs.zsh.profileExtra` に nix-daemon の sourcing を追加し、e2e テストで `.zprofile` が存在しない問題を修正した

## テスト計画
- [ ] e2e-setup-test CI が pass すること
- [ ] zsh 起動時に補完候補が直前コマンド優先で表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)