### PR TITLE
fix(ci): github-actions[bot] によるハッシュ更新コミット時にワークフローをスキップする

### DIFF
--- a/.github/workflows/nix-update-pr.yaml
+++ b/.github/workflows/nix-update-pr.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   update-hashes:
     # Renovate が開いた PR のみ対象・GitHub App による push は無限ループ防止のためスキップ
-    if: startsWith(github.head_ref, 'renovate/') && github.actor != 'rito528-dotfiles-bot[bot]'
+    if: startsWith(github.head_ref, 'renovate/') && github.actor != 'github-actions[bot]'
     runs-on: ubuntu-24.04
     permissions:
       contents: write


### PR DESCRIPTION
## 概要

- `nix-update-pr.yaml` のスキップ条件を修正 (issue #157)
- `rito528-dotfiles-bot[bot]` との完全一致ではなく、`github-actions[bot]` との完全一致でスキップするよう変更

## テスト計画

- [ ] Renovate PR が来た際にワークフローが正常に実行されること
- [ ] ボットがコミットを push した際にワークフローがスキップされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)