### PR TITLE
feat(hooks): editorconfig-checker の pre-commit フックをこのリポジトリ専用に限定する

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v gitleaks &>/dev/null; then
+  echo "gitleaks is not installed. Cannot secret check."
+  exit 1
+fi
+
+gitleaks protect --staged --redact
+
+# editorconfig チェック (staged ファイルのみ)
+if ! command -v editorconfig-checker &>/dev/null; then
+  echo "editorconfig-checker is not installed. Cannot editorconfig check."
+  exit 1
+fi
+
+git diff --cached --name-only --diff-filter=ACM | xargs -r editorconfig-checker

--- a/config/git/hooks/pre-commit
+++ b/config/git/hooks/pre-commit
@@ -7,11 +7,3 @@ if ! command -v gitleaks &>/dev/null; then
 fi
 
 gitleaks protect --staged --redact
-
-# editorconfig チェック (staged ファイルのみ)
-if ! command -v editorconfig-checker &>/dev/null; then
-  echo "editorconfig-checker is not installed. Cannot editorconfig check."
-  exit 1
-fi
-
-git diff --cached --name-only --diff-filter=ACM | xargs -r editorconfig-checker

--- a/install/common/setup-local-hooks.sh
+++ b/install/common/setup-local-hooks.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+current="$(git -C "$REPO_DIR" config --local core.hooksPath 2>/dev/null || true)"
+
+if [ "$current" = ".githooks" ]; then
+  echo "core.hooksPath is already set to .githooks. Skipping."
+  exit 0
+fi
+
+git -C "$REPO_DIR" config --local core.hooksPath .githooks
+echo "core.hooksPath set to .githooks."

--- a/setup.sh
+++ b/setup.sh
@@ -26,4 +26,7 @@ echo "==> Applying home-manager configuration..."
 echo "==> Configuring login shell (zsh)..."
 "$REPO_DIR/install/common/chsh-zsh.sh"
 
+echo "==> Setting up local git hooks..."
+"$REPO_DIR/install/common/setup-local-hooks.sh"
+
 echo "Setup complete."


### PR DESCRIPTION
## 概要

- グローバルフック (`~/.config/git/hooks/pre-commit`) から `editorconfig-checker` を削除し、gitleaks のみに絞る
- `.githooks/pre-commit` を新規作成し、gitleaks + editorconfig-checker 両方を含むリポジトリローカルのフックとして管理する
- `install/common/setup-local-hooks.sh` を追加し、`core.hooksPath = .githooks` をこのリポジトリのローカル設定に書き込む（冪等）
- `setup.sh` から `setup-local-hooks.sh` を呼び出すことで、setup.sh 一発で完結するセットアップ思想を維持する

## テスト計画

- [ ] `setup.sh` を実行後、このリポジトリで `git config --local core.hooksPath` が `.githooks` になっていること
- [ ] このリポジトリでコミット時に editorconfig-checker が動作すること
- [ ] 別のリポジトリでコミット時に editorconfig-checker が動作しないこと（gitleaks のみ）
- [ ] `setup-local-hooks.sh` を2回実行してもエラーにならないこと（冪等性）

🤖 Generated with [Claude Code](https://claude.com/claude-code)