### PR TITLE
feat: Doppler から CA 証明書を取得してシステムトラストストアに登録する

### DIFF
--- a/install/common/ca-certs.sh
+++ b/install/common/ca-certs.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Install CA certificate from Doppler into system trust store
+# Usage: ./install/common/ca-certs.sh
+
+set -euo pipefail
+
+CERT_NAME="corporate-ca"
+CERT_PATH="/usr/local/share/ca-certificates/${CERT_NAME}.crt"
+
+# CI環境ではスキップ
+if [ "${CI:-}" = "true" ]; then
+  echo "CI environment detected, skipping CA cert installation"
+  exit 0
+fi
+
+# すでにインストール済みならスキップ（冪等性）
+if [ -f "$CERT_PATH" ]; then
+  echo "CA cert already installed at $CERT_PATH, skipping"
+  exit 0
+fi
+
+# Doppler 認証チェック
+if ! doppler whoami &>/dev/null; then
+  echo "Warning: Doppler not authenticated, skipping CA cert installation"
+  exit 0
+fi
+
+echo "Installing CA certificate..."
+doppler secrets get CA_CERT --plain --project keys --config prd | sudo tee "$CERT_PATH" > /dev/null
+sudo chmod 644 "$CERT_PATH"
+sudo update-ca-certificates
+
+echo "CA certificate installed successfully"

--- a/install/ubuntu/packages.sh
+++ b/install/ubuntu/packages.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 PACKAGES=(
     curl
+    ca-certificates
 )
 
 echo "Updating package list..."

--- a/setup.sh
+++ b/setup.sh
@@ -17,6 +17,9 @@ echo "==> Installing packages..."
 echo "==> Installing Docker..."
 "$REPO_DIR/install/ubuntu/docker.sh"
 
+echo "==> Installing CA certificate..."
+"$REPO_DIR/install/common/ca-certs.sh"
+
 echo "==> Installing Nix..."
 "$REPO_DIR/install/common/nix.sh"
 


### PR DESCRIPTION
## 概要

- `install/common/ca-certs.sh` を新規作成。Doppler (`keys/prd`) の `CA_CERT` シークレットから証明書を取得し `update-ca-certificates` でシステムに登録する
- `install/ubuntu/packages.sh` に `ca-certificates` パッケージを追加
- `setup.sh` から `ca-certs.sh` を呼び出すよう追記（Nix インストール前に実行）

## テスト計画

- [ ] Doppler に `CA_CERT` を PEM 形式で登録済みの状態で `bash install/common/ca-certs.sh` を実行し、`/usr/local/share/ca-certificates/corporate-ca.crt` が作成されることを確認
- [ ] 再実行でスキップメッセージが出ることを確認（冪等性）
- [ ] `CI=true` でスキップされることを確認
- [ ] Doppler 未認証時に Warning が出てスキップされることを確認
- [ ] `shellcheck install/common/ca-certs.sh` が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)