### PR TITLE
feat: git branch コマンドを許可リストに追加

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -36,6 +36,8 @@
       "Bash(cd *)",
       "Bash(git log *)",
       "Bash(git -C * log *)",
+      "Bash(git branch *)",
+      "Bash(git -C * branch *)",
       "Bash(git fetch *)",
       "Bash(git -C * fetch *)",
       "Bash(git switch *)",


### PR DESCRIPTION
## 概要
- `git branch` および `git -C * branch *` を Claude Code の permissions allow リストに追加
- これにより `git branch` 実行時の許可確認ダイアログが不要になる

## テスト計画
- [ ] `git branch` 実行時に許可確認が出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)