### PR TITLE
.sh ファイルの実行権限チェックを pre-commit に追加

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -15,3 +15,20 @@ if ! command -v editorconfig-checker &>/dev/null; then
 fi
 
 git diff --cached --name-only --diff-filter=ACM | xargs -r editorconfig-checker
+
+# ステージされた .sh ファイルに実行権限があるか確認する
+missing_exec=()
+while IFS= read -r file; do
+  if [[ -f "$file" ]] && ! [[ -x "$file" ]]; then
+    missing_exec+=("$file")
+  fi
+done < <(git diff --cached --name-only --diff-filter=ACM | grep '\.sh$')
+
+if [[ ${#missing_exec[@]} -gt 0 ]]; then
+  echo "Error: The following shell scripts are missing execute permission:"
+  for f in "${missing_exec[@]}"; do
+    echo "  $f"
+  done
+  echo "Run: chmod +x <file> and re-stage."
+  exit 1
+fi


### PR DESCRIPTION
## 概要
- ステージされた `.sh` ファイルに実行権限がない場合、コミットを拒否するチェックを `.githooks/pre-commit` に追加
- 実行権限のないシェルスクリプトが誤ってリポジトリに追加されるのを防ぐ

## テスト計画
- [ ] 実行権限なしの `.sh` ファイルをステージしてコミットが拒否されることを確認
- [ ] 実行権限ありの `.sh` ファイルをステージしてコミットが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)