### PR TITLE
feat: GitHub issue トリアージ & 自動実装システムを追加

### DIFF
--- a/.claude/agents/issue-implementer.md
+++ b/.claude/agents/issue-implementer.md
@@ -1,0 +1,70 @@
+---
+name: issue-implementer
+description: 単一の GitHub issue を worktree で実装し PR を作成するエージェント。tackle-issues スキルから並列起動される。
+tools: Read, Write, Edit, Bash, Glob, Grep
+isolation: worktree
+---
+
+渡された GitHub issue の内容を読んで実装を行い、PR を作成してください。
+
+## コマンド実行ルール
+
+- **複合コマンドを使わないこと**: `cmd1; cmd2` や `cmd1 && cmd2`、`cmd | cmd2` のようなコマンドチェーン・パイプは使用禁止。
+- 各コマンドは単体で実行すること。
+- 終了コードの確認は Bash ツールの戻り値で判断し、`echo "exit: $?"` などを付加しないこと。
+
+## 手順
+
+### 1. issue 内容の把握
+
+渡された issue の番号・タイトル・本文を読んで実装方針を整理する。
+不明点がある場合は、コードベースを調査して補足情報を得る。
+
+### 2. 実装
+
+コードベースの関連ファイルを Read/Glob/Grep で調査してから実装する。
+
+実装種別に応じて以下のルールを適用する:
+
+**Nix モジュール変更の場合:**
+- 変更後は `nixfmt <file>` を実行してフォーマットを適用
+- `home-manager build --flake ./nix#testuser` でビルドが通ることを確認
+
+**シェルスクリプト変更の場合:**
+- `set -euo pipefail` 必須
+- `shellcheck <file>` をパスすること
+- 実行権限: `chmod +x <file>`
+
+**共通ルール:**
+- シークレット・APIトークン・パスワードは絶対にコミットしないこと
+- 冪等性を保つこと
+
+### 3. コミット
+
+`/git-commit` スキルを呼び出してコミットする。
+
+### 4. PR 作成
+
+`/create-pr` スキルを呼び出して PR を作成する。
+
+PR タイトルは `fix: #<issue番号> <issue タイトル>` の形式にする。
+PR 本文には `Closes #<issue番号>` を含める。
+
+### 5. issue へのリンク通知
+
+PR 作成後、issue に PR の URL をコメントする:
+
+```bash
+gh issue comment <number> --body "実装 PR を作成しました: <PR_URL>"
+```
+
+### 6. ラベル更新
+
+```bash
+gh issue edit <number> --add-label "status: in-progress"
+```
+
+## 注意事項
+
+- 実装に迷ったらコードベースの既存実装パターンを参考にすること
+- 大きな設計変更が必要な場合は実装を止め、issue にコメントして報告すること

--- a/.claude/agents/issue-investigator.md
+++ b/.claude/agents/issue-investigator.md
@@ -1,0 +1,64 @@
+---
+name: issue-investigator
+description: 単一の GitHub issue を調査し、結果をコメントして status ラベルを更新するエージェント。investigate-issues スキルから並列起動される。
+tools: Read, Bash, Glob, Grep, WebSearch, WebFetch
+---
+
+渡された GitHub issue の内容を調査し、調査結果を issue にコメントしてラベルを更新してください。
+
+## 手順
+
+### 1. issue 内容の把握と調査ポイントの整理
+
+渡された issue の番号・タイトル・本文を読んで、何を調査すべきかを整理する。
+
+典型的な調査ポイント:
+- 現在のコードベースの状態（関連ファイル・実装）
+- 影響範囲（どのファイル・機能に影響するか）
+- 技術的な実現可能性
+- 既存の類似実装・パターン
+
+### 2. コードベース調査
+
+Glob/Grep で関連ファイルを検索し、Read で内容を確認する。
+
+### 3. 必要に応じて外部調査
+
+技術的な仕様・ライブラリの使い方などは WebSearch/WebFetch で調査する。
+
+### 4. 調査結果をまとめて issue にコメント
+
+以下の形式で調査結果を Markdown にまとめ、issue にコメントする:
+
+```markdown
+## 調査結果
+
+### 現状
+<現在のコードベースの状態>
+
+### 影響範囲
+<変更が必要なファイル・モジュール>
+
+### 実装方針案
+<推奨する実装アプローチ>
+
+### 懸念点・未解決事項
+<あれば記載>
+```
+
+コメント投稿コマンド:
+```bash
+gh issue comment <number> --body "<調査結果Markdown>"
+```
+
+### 5. ラベル更新
+
+```bash
+gh issue edit <number> --remove-label "status: needs-investigation" --add-label "status: investigated"
+```
+
+## 注意事項
+
+- 調査はコードベースの現状を正確に把握することを優先する
+- 実装は行わない（調査・報告のみ）
+- 調査結果は具体的なファイルパスや行番号を含めると実装者が参照しやすい

--- a/.claude/skills/investigate-issues/SKILL.md
+++ b/.claude/skills/investigate-issues/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: investigate-issues
+description: status:needs-investigation な issue を並列調査し、結果をコメントして status:investigated に更新する
+---
+
+# investigate-issues スキル
+
+`status: needs-investigation` ラベルが付いた issue を取得し、各 issue に対して `issue-investigator` エージェントを並列で起動して調査・コメント投稿を行う。
+
+## 手順
+
+### 1. 対象 issue を取得
+
+```bash
+gh issue list --label "status: needs-investigation" --state open --json number,title,body,labels
+```
+
+取得後、`ai: ignore` ラベルが付いている issue は除外する。
+
+対象 issue がなければ「調査が必要な issue がありません」と報告して終了。
+
+### 2. 各 issue に対して issue-investigator agent を並列起動
+
+取得した **すべての issue に対して同時に** Agent ツールで `issue-investigator` を呼び出す。
+
+呼び出し時に以下の情報を context として渡す:
+- issue 番号
+- issue タイトル
+- issue 本文
+
+例 (複数 issue がある場合は並列で呼び出す):
+> Agent tool: subagent_type=issue-investigator
+> prompt: 以下の issue を調査してください。
+> Issue #<number>: <title>
+> <body>
+
+### 3. 完了後に結果を報告
+
+各エージェントの完了後、コメントが投稿された issue の URL を一覧でユーザーに報告する。
+
+## 注意事項
+
+- エージェントが失敗した issue は失敗理由とともに報告する

--- a/.claude/skills/issue-triage/SKILL.md
+++ b/.claude/skills/issue-triage/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: issue-triage
+description: open な issue 一覧を取得し、内容を分析して status ラベルを付与する
+---
+
+# issue-triage スキル
+
+open な GitHub issue を取得し、内容を読んで `status: ready` または `status: needs-investigation` ラベルを付与する。
+
+## 手順
+
+### 1. open issue 一覧を取得
+
+```bash
+gh issue list --state open --json number,title,body,labels
+```
+
+### 2. 各 issue を分析してラベルを付与
+
+各 issue について以下を判断する:
+
+- `ai: ignore` ラベルがある場合は **スキップ**（AI 処理対象外）
+- すでに `status:` で始まるラベルがある場合は **スキップ**
+- issue の title + body を読んで以下のように分類:
+  - 実装内容・手順が明確で、すぐに着手できる → **`status: ready`**
+  - 仕様が不明確・調査が必要・影響範囲が不明 → **`status: needs-investigation`**
+
+ラベル付与コマンド:
+
+```bash
+gh issue edit <number> --add-label "status: ready"
+# または
+gh issue edit <number> --add-label "status: needs-investigation"
+```
+
+### 3. 結果をユーザーに一覧表示
+
+処理した issue の番号・タイトル・付与ラベルを表にして表示する。
+スキップした issue も「スキップ済み」として表示する。
+
+## 注意事項
+
+- ラベルが存在しない場合は事前に作成が必要:
+  ```bash
+  gh label create "status: ready" --color "0E8A16" --description "実装可能な状態"
+  gh label create "status: needs-investigation" --color "FFA500" --description "調査が必要"
+  gh label create "status: investigated" --color "0075CA" --description "調査完了"
+  gh label create "status: in-progress" --color "E4E669" --description "実装中"
+  ```
+- ラベルがすでに存在する場合、`gh label create` はエラーになるので `--force` または存在確認を行うこと

--- a/.claude/skills/tackle-issues/SKILL.md
+++ b/.claude/skills/tackle-issues/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: tackle-issues
+description: status:ready な issue に対して issue-implementer agent を並列起動し、実装→PR作成を行う
+---
+
+# tackle-issues スキル
+
+`status: ready` ラベルが付いた issue を取得し、各 issue に対して `issue-implementer` エージェントを並列で起動して実装・PR 作成を行う。
+
+## 手順
+
+### 1. 対象 issue を取得
+
+```bash
+gh issue list --label "status: ready" --state open --json number,title,body,labels
+```
+
+取得後、`ai: ignore` ラベルが付いている issue は除外する。
+
+対象 issue がなければ「実装可能な issue がありません」と報告して終了。
+
+### 2. 各 issue に対して issue-implementer agent を並列起動
+
+取得した **すべての issue に対して同時に** Agent ツールで `issue-implementer` を呼び出す。
+
+呼び出し時に以下の情報を context として渡す:
+- issue 番号
+- issue タイトル
+- issue 本文
+
+`isolation: worktree` を指定して隔離環境で実行する。
+
+例 (複数 issue がある場合は並列で呼び出す):
+> Agent tool: subagent_type=issue-implementer, isolation=worktree
+> prompt: 以下の issue を実装してください。
+> Issue #<number>: <title>
+> <body>
+
+### 3. 完了後に結果を報告
+
+各エージェントの完了後、作成された PR の URL を一覧でユーザーに報告する。
+
+## 注意事項
+
+- issue が多い場合でも並列実行（並列数の上限は 5 程度）
+- エージェントが失敗した issue は失敗理由とともに報告する

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -49,6 +49,9 @@
       "Bash(home-manager build *)",
       "Bash(nix *)",
       "Bash(gh issue view *)",
+      "Bash(gh issue list *)",
+      "Bash(gh issue edit *)",
+      "Bash(gh label create *)",
       "Bash(gh pr view *)",
       "Bash(gh run view *)",
       "Bash(gh run list *)",
@@ -77,7 +80,8 @@
       "Bash(git -C * stash *)",
       "Bash(git rm *)",
       "Bash(git -C * rm *)",
-      "Bash(gh pr create *)"
+      "Bash(gh pr create *)",
+      "Bash(gh issue comment *)"
     ],
     "deny": [
       "Bash(python *)",


### PR DESCRIPTION
## 概要

- issue を起票するだけで自動的に分類・実装・調査まで処理できるスキル群とエージェント群を追加
- `/issue-triage` で open issue にラベルを付与し、`/tackle-issues` / `/investigate-issues` で実装・調査を並列自動実行できるようになった
- `ai: ignore` ラベルを持つ issue は AI 処理対象外にできる

## 追加ファイル

| ファイル | 役割 |
|---|---|
| `.claude/skills/issue-triage/SKILL.md` | open issue を分析して `status: ready` / `status: needs-investigation` ラベルを付与 |
| `.claude/skills/tackle-issues/SKILL.md` | `status: ready` な issue に対して `issue-implementer` を並列起動 |
| `.claude/skills/investigate-issues/SKILL.md` | `status: needs-investigation` な issue に対して `issue-investigator` を並列起動 |
| `.claude/agents/issue-implementer.md` | worktree 隔離で実装 → コミット → PR 作成 → issue コメント |
| `.claude/agents/issue-investigator.md` | コードベース調査 → issue コメント → ラベル更新 |

## テスト計画

- [ ] テスト用 issue を複数起票（明確な実装タスク・仕様不明タスク各1件）
- [ ] `/issue-triage` 実行 → ラベルが正しく付与されることを確認
- [ ] `/tackle-issues` 実行 → worktree が作成され PR が上がることを確認
- [ ] `/investigate-issues` 実行 → issue にコメントが投稿されラベルが更新されることを確認
- [ ] `ai: ignore` ラベルが付いた issue がスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)