### PR TITLE
fix: #184 よく使うプロジェクト向け dev-shell とテンプレートを追加

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -82,6 +82,22 @@
           path = ./templates/typescript;
           description = "TypeScript (pnpm) development environment";
         };
+        seichi-assist = {
+          path = ./templates/seichi-assist;
+          description = "SeichiAssist development environment";
+        };
+        seichi-infra = {
+          path = ./templates/seichi-infra;
+          description = "seichi-infra development environment";
+        };
+        seichi-portal-backend = {
+          path = ./templates/seichi-portal-backend;
+          description = "seichi-portal-backend development environment";
+        };
+        seichi-portal-frontend = {
+          path = ./templates/seichi-portal-frontend;
+          description = "seichi-portal-frontend development environment";
+        };
       };
       devShells.${system} = {
         rust = pkgsWithRust.mkShell {
@@ -104,6 +120,41 @@
           '';
         };
         typescript = pkgs.mkShell {
+          buildInputs = [
+            pkgs.nodejs_22
+            pkgs.pnpm
+          ];
+        };
+        seichi-assist = pkgs.mkShell {
+          buildInputs = [
+            pkgs.jdk17
+            pkgs.sbt
+            pkgs.metals
+            pkgs.scalafmt
+            pkgs.stdenv.cc.cc.lib
+          ];
+          shellHook = ''
+            export LD_LIBRARY_PATH="${pkgs.stdenv.cc.cc.lib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+          '';
+        };
+        seichi-infra = pkgs.mkShell {
+          buildInputs = [
+            pkgs.terraform
+            pkgs.tflint
+            pkgs.kubectl
+            pkgs.kubernetes-helm
+          ];
+        };
+        seichi-portal-backend = pkgsWithRust.mkShell {
+          buildInputs = [
+            pkgsWithRust.rust-bin.stable.latest.default
+            pkgsWithRust.pkg-config
+            pkgsWithRust.openssl
+            pkgsWithRust.cargo-make
+            pkgsWithRust.sqlx-cli
+          ];
+        };
+        seichi-portal-frontend = pkgs.mkShell {
           buildInputs = [
             pkgs.nodejs_22
             pkgs.pnpm

--- a/nix/templates/seichi-assist/flake.nix
+++ b/nix/templates/seichi-assist/flake.nix
@@ -1,0 +1,26 @@
+{
+  description = "SeichiAssist development environment";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs =
+    { nixpkgs, ... }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; };
+    in
+    {
+      devShells.${system}.default = pkgs.mkShell {
+        buildInputs = [
+          pkgs.jdk17
+          pkgs.sbt
+          pkgs.metals
+          pkgs.scalafmt
+          pkgs.stdenv.cc.cc.lib
+        ];
+        shellHook = ''
+          export LD_LIBRARY_PATH="${pkgs.stdenv.cc.cc.lib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+        '';
+      };
+    };
+}

--- a/nix/templates/seichi-infra/flake.nix
+++ b/nix/templates/seichi-infra/flake.nix
@@ -1,0 +1,22 @@
+{
+  description = "seichi-infra development environment";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs =
+    { nixpkgs, ... }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; };
+    in
+    {
+      devShells.${system}.default = pkgs.mkShell {
+        buildInputs = [
+          pkgs.terraform
+          pkgs.tflint
+          pkgs.kubectl
+          pkgs.kubernetes-helm
+        ];
+      };
+    };
+}

--- a/nix/templates/seichi-portal-backend/flake.nix
+++ b/nix/templates/seichi-portal-backend/flake.nix
@@ -1,0 +1,32 @@
+{
+  description = "seichi-portal-backend development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    { nixpkgs, rust-overlay, ... }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [ rust-overlay.overlays.default ];
+      };
+    in
+    {
+      devShells.${system}.default = pkgs.mkShell {
+        buildInputs = [
+          pkgs.rust-bin.stable.latest.default
+          pkgs.pkg-config
+          pkgs.openssl
+          pkgs.cargo-make
+          pkgs.sqlx-cli
+        ];
+      };
+    };
+}

--- a/nix/templates/seichi-portal-frontend/flake.nix
+++ b/nix/templates/seichi-portal-frontend/flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "seichi-portal-frontend development environment";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs =
+    { nixpkgs, ... }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; };
+    in
+    {
+      devShells.${system}.default = pkgs.mkShell {
+        buildInputs = [
+          pkgs.nodejs_22
+          pkgs.pnpm
+        ];
+      };
+    };
+}


### PR DESCRIPTION
## Summary

- GiganticMinecraft の各プロジェクト向けに専用の `devShells` と `templates` を追加
- `nix/flake.nix` に 4 つの新しい devShell を追加
- `nix/templates/` に対応する 4 つのテンプレートを追加

| 名前 | 用途 | 主なツール |
|------|------|-----------|
| `seichi-assist` | SeichiAssist (Scala) | JDK17, sbt, metals, scalafmt |
| `seichi-infra` | seichi-infra (Terraform/K8s) | terraform, tflint, kubectl, helm |
| `seichi-portal-backend` | seichi-portal-backend (Rust) | rust stable, cargo-make, sqlx-cli |
| `seichi-portal-frontend` | seichi-portal-frontend (Next.js) | Node.js 22, pnpm |

Closes #184

## Test plan

- [ ] `nixfmt` が全 `.nix` ファイルに適用済み
- [ ] CI の `home-manager build` が通ること
- [ ] `nix flake check` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)