### PR TITLE
fix: issue-implementer が Skill ツールを使えるよう修正

### DIFF
--- a/.claude/agents/issue-implementer.md
+++ b/.claude/agents/issue-implementer.md
@@ -1,7 +1,7 @@
 ---
 name: issue-implementer
 description: 単一の GitHub issue を worktree で実装し PR を作成するエージェント。tackle-issues スキルから並列起動される。
-tools: Read, Write, Edit, Bash, Glob, Grep
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 isolation: worktree
 ---
 


### PR DESCRIPTION
## 概要

- `issue-implementer` エージェントの `tools` リストに `Skill` が含まれていなかったため、`/git-commit` や `/create-pr` スキルを呼び出せない問題を修正
- スキル呼び出しができないエージェントが生の `git commit` を実行し、`--no-gpg-sign` なしでコミットしようとして GPG 署名を要求される現象の根本原因

## テスト計画

- [ ] `issue-implementer` が `/git-commit` スキルを正しく呼び出せることを確認
- [ ] GPG 署名を要求されることなくコミットが完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)