### PR TITLE
fix: global gitignore に .envrc を追加

### DIFF
--- a/modules/git.nix
+++ b/modules/git.nix
@@ -10,6 +10,7 @@
       ".idea/"
       ".vscode/"
       ".env"
+      ".envrc"
       ".env.local"
       ".claude/settings.local.json"
       ".claude/worktrees/"


### PR DESCRIPTION
## 概要
- global gitignore に `.envrc` を追加
- direnv のローカル設定が誤って追跡対象になるのを防ぐ

## テスト計画
- [x] `nixfmt modules/git.nix`
- [x] `home-manager build --flake .#testuser`

🤖 Generated with Codex