### PR TITLE
fix: .direnv をグローバル gitignore に追加

### DIFF
--- a/modules/git.nix
+++ b/modules/git.nix
@@ -10,6 +10,7 @@
       ".idea/"
       ".vscode/"
       ".codex/"
+      ".direnv/"
       ".env"
       ".envrc"
       ".env.local"


### PR DESCRIPTION
## 概要
- グローバル gitignore に `.direnv/` を追加
- direnv が生成するローカル状態を誤って追跡しないように調整

## テスト計画
- [ ] 未実施（gitignore 1 行追加のみを確認）

🤖 Generated with Codex