### PR TITLE
fix: Codex sandbox 設定を調整

### DIFF
--- a/modules/codex.nix
+++ b/modules/codex.nix
@@ -8,6 +8,8 @@ let
   codexConfig = {
     model = "gpt-5.4";
     model_reasoning_effort = "medium";
+    sandbox_mode = "workspace-write";
+    sandbox_workspace_write.writable_roots = [ "/tmp" ];
 
     projects."${homeDirectory}".trust_level = "trusted";
 


### PR DESCRIPTION
## 概要
- Codex CLI の設定で `workspace-write` をデフォルトにし、`/tmp` を writable root に追加した

## テスト計画
- [ ] `home-manager switch` で Codex 設定の反映を確認
- [ ] `workspace-write` と `/tmp` への書き込みが期待どおり動くことを実運用で確認

🤖 Generated with Codex