### PR TITLE
fix: GitHub Actions Renovate updates before weekly flake lock

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,17 +3,26 @@
   "extends": [
     "config:recommended"
   ],
-  "gitIgnoredAuthors": ["github-actions[bot]@users.noreply.github.com"],
+  "timezone": "Asia/Tokyo",
+  "gitIgnoredAuthors": [
+    "github-actions[bot]@users.noreply.github.com"
+  ],
   "automerge": true,
   "automergeType": "pr",
   "platformAutomerge": true,
+  "updateNotScheduled": false,
   "packageRules": [
     {
       "matchDepTypes": [
         "action"
       ],
       "pinDigests": true,
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "6 days",
+      "internalChecksFilter": "strict",
+      "prCreation": "not-pending",
+      "schedule": [
+        "* * * * 0"
+      ]
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## 概要
- GitHub Actions の Renovate 更新に \\`timezone\\` と週次 \\`schedule\\` を追加し、月曜 JST の \\`flake.lock\\` 更新前日にだけ PR を出すようにします
- \\`minimumReleaseAge\\` を 6 日に短縮し、\\`prCreation: \"not-pending\"\\` と \\`internalChecksFilter: \"strict\"\\` で待機中の PR 作成を抑止します
- \\`updateNotScheduled: false\\` を追加し、週次窓の外で GitHub Actions の digest pin が揺れ続けるのを防ぎます

## テスト計画
- [ ] \\`npx --yes renovate --platform=local --dry-run=full\\` を実行して Renovate 設定が妥当であることを確認する
- [ ] GitHub Actions の Renovate PR が平日に新規作成・更新されないことを確認する
- [ ] 日曜 JST に対象 PR が作成され、月曜 09:00 JST の \\`flake.lock\\` 更新 PR より前にマージ可能であることを確認する

🤖 Generated with Codex