### PR TITLE
fix: .codex ファイルをグローバル gitignore に追加

### DIFF
--- a/modules/git.nix
+++ b/modules/git.nix
@@ -9,6 +9,7 @@
     ignores = [
       ".idea/"
       ".vscode/"
+      ".codex"
       ".codex/"
       ".direnv/"
       ".env"


### PR DESCRIPTION
## 概要
- Codex 実行時に生成される単体ファイル `.codex` をグローバル gitignore の対象に追加
- 既存の `.codex/` ディレクトリ ignore に加えて、ファイル生成時も未追跡変更として残らないように調整

## テスト計画
- [ ] `home-manager build --flake .#testuser`
- [ ] `.codex` ファイル作成時に `git status --short` へ表示されないことを確認

🤖 Generated with Codex
