### PR TITLE
fix: Codex の安全なコマンド許可ルールを整備する

### DIFF
--- a/modules/codex.nix
+++ b/modules/codex.nix
@@ -5,34 +5,47 @@
 }:
 let
   tomlFormat = pkgs.formats.toml { };
-  codexRules = pkgs.writeText "codex-default.rules" ''
-    prefix_rule(pattern=["rg"], decision="allow")
-    prefix_rule(pattern=["grep"], decision="allow")
-    prefix_rule(pattern=["ls"], decision="allow")
-    prefix_rule(pattern=["tree"], decision="allow")
-    prefix_rule(pattern=["pwd"], decision="allow")
-
-    prefix_rule(pattern=["git", "status"], decision="allow")
-    prefix_rule(pattern=["git", "diff"], decision="allow")
-    prefix_rule(pattern=["git", "log"], decision="allow")
-    prefix_rule(pattern=["git", "branch"], decision="allow")
-    prefix_rule(pattern=["git", "fetch"], decision="allow")
-    prefix_rule(pattern=["git", "switch"], decision="allow")
-    prefix_rule(pattern=["git", "pull"], decision="allow")
-
-    prefix_rule(pattern=["shellcheck"], decision="allow")
-    prefix_rule(pattern=["nixfmt"], decision="allow")
-    prefix_rule(pattern=["home-manager", "build"], decision="allow")
-    prefix_rule(pattern=["nix"], decision="allow")
-    prefix_rule(pattern=["nix-build"], decision="allow")
-
-    prefix_rule(pattern=["gh", "issue", "view"], decision="allow")
-    prefix_rule(pattern=["gh", "issue", "list"], decision="allow")
-    prefix_rule(pattern=["gh", "pr", "list"], decision="allow")
-    prefix_rule(pattern=["gh", "pr", "view"], decision="allow")
-    prefix_rule(pattern=["gh", "run", "view"], decision="allow")
-    prefix_rule(pattern=["gh", "run", "list"], decision="allow")
-  '';
+  shellReadPrefixes = [
+    "rg"
+    "grep"
+    "ls"
+    "tree"
+    "pwd"
+  ];
+  gitReadPrefixes = [
+    "git status"
+    "git diff"
+    "git log"
+    "git branch"
+    "git fetch"
+    "git switch"
+    "git pull"
+  ];
+  buildPrefixes = [
+    "shellcheck"
+    "nixfmt"
+    "home-manager build"
+    "nix"
+    "nix-build"
+  ];
+  githubReadPrefixes = [
+    "gh issue view"
+    "gh issue list"
+    "gh pr list"
+    "gh pr view"
+    "gh run view"
+    "gh run list"
+  ];
+  allowCommandPrefixes = shellReadPrefixes ++ gitReadPrefixes ++ buildPrefixes ++ githubReadPrefixes;
+  renderPrefixRule =
+    prefix:
+    let
+      pattern = pkgs.lib.splitString " " prefix;
+    in
+    ''prefix_rule(pattern=${builtins.toJSON pattern}, decision="allow")'';
+  codexRules = pkgs.writeText "codex-default.rules" (
+    builtins.concatStringsSep "\n" (map renderPrefixRule allowCommandPrefixes) + "\n"
+  );
   codexConfig = {
     model = "gpt-5.4";
     model_reasoning_effort = "medium";

--- a/modules/codex.nix
+++ b/modules/codex.nix
@@ -5,6 +5,34 @@
 }:
 let
   tomlFormat = pkgs.formats.toml { };
+  codexRules = pkgs.writeText "codex-default.rules" ''
+    prefix_rule(pattern=["rg"], decision="allow")
+    prefix_rule(pattern=["grep"], decision="allow")
+    prefix_rule(pattern=["ls"], decision="allow")
+    prefix_rule(pattern=["tree"], decision="allow")
+    prefix_rule(pattern=["pwd"], decision="allow")
+
+    prefix_rule(pattern=["git", "status"], decision="allow")
+    prefix_rule(pattern=["git", "diff"], decision="allow")
+    prefix_rule(pattern=["git", "log"], decision="allow")
+    prefix_rule(pattern=["git", "branch"], decision="allow")
+    prefix_rule(pattern=["git", "fetch"], decision="allow")
+    prefix_rule(pattern=["git", "switch"], decision="allow")
+    prefix_rule(pattern=["git", "pull"], decision="allow")
+
+    prefix_rule(pattern=["shellcheck"], decision="allow")
+    prefix_rule(pattern=["nixfmt"], decision="allow")
+    prefix_rule(pattern=["home-manager", "build"], decision="allow")
+    prefix_rule(pattern=["nix"], decision="allow")
+    prefix_rule(pattern=["nix-build"], decision="allow")
+
+    prefix_rule(pattern=["gh", "issue", "view"], decision="allow")
+    prefix_rule(pattern=["gh", "issue", "list"], decision="allow")
+    prefix_rule(pattern=["gh", "pr", "list"], decision="allow")
+    prefix_rule(pattern=["gh", "pr", "view"], decision="allow")
+    prefix_rule(pattern=["gh", "run", "view"], decision="allow")
+    prefix_rule(pattern=["gh", "run", "list"], decision="allow")
+  '';
   codexConfig = {
     model = "gpt-5.4";
     model_reasoning_effort = "medium";
@@ -33,5 +61,10 @@ in
   home.file.".codex/config.toml" = {
     force = true;
     source = tomlFormat.generate "codex-config.toml" codexConfig;
+  };
+
+  home.file.".codex/rules/default.rules" = {
+    force = true;
+    source = codexRules;
   };
 }


### PR DESCRIPTION
## 概要
- Codex 向けに安全な読み取り系・ローカル検証系コマンドの default rules を追加
- Claude Code の permissions と AGENTS.md の基準に合わせ、不要な確認を減らす設定を home-manager で配備
- nixfmt 後も読みやすいように、許可する command prefix をカテゴリ別の文字列リストとして整理

## テスト計画
- [x] `nixfmt modules/codex.nix`
- [x] `home-manager build --flake .#testuser`

🤖 Generated with Codex
