### PR TITLE
fix: Codex の PR 作成関連コマンドを許可する

### DIFF
--- a/modules/codex.nix
+++ b/modules/codex.nix
@@ -5,21 +5,30 @@
 }:
 let
   tomlFormat = pkgs.formats.toml { };
-  shellReadPrefixes = [
+  shellUtilityPrefixes = [
     "rg"
     "grep"
     "ls"
     "tree"
     "pwd"
+    "mkdir"
+    "cat"
   ];
   gitReadPrefixes = [
     "git status"
     "git diff"
     "git log"
     "git branch"
+    "git branch --show-current"
     "git fetch"
     "git switch"
+    "git switch -c"
     "git pull"
+  ];
+  gitLocalWritePrefixes = [
+    "git add"
+    "git commit"
+    "git commit --no-gpg-sign"
   ];
   buildPrefixes = [
     "shellcheck"
@@ -27,6 +36,19 @@ let
     "home-manager build"
     "nix"
     "nix-build"
+    "cargo"
+    "sbt"
+    "sbtn"
+  ];
+  dockerLocalPrefixes = [
+    "docker build"
+    "docker buildx build"
+    "docker ps"
+    "docker images"
+  ];
+  tempFilePrefixes = [
+    "mktemp"
+    "printf"
   ];
   githubReadPrefixes = [
     "gh issue view"
@@ -36,7 +58,14 @@ let
     "gh run view"
     "gh run list"
   ];
-  allowCommandPrefixes = shellReadPrefixes ++ gitReadPrefixes ++ buildPrefixes ++ githubReadPrefixes;
+  allowCommandPrefixes =
+    shellUtilityPrefixes
+    ++ gitReadPrefixes
+    ++ gitLocalWritePrefixes
+    ++ buildPrefixes
+    ++ dockerLocalPrefixes
+    ++ tempFilePrefixes
+    ++ githubReadPrefixes;
   renderPrefixRule =
     prefix:
     let


### PR DESCRIPTION
## 概要
- Codex の許可コマンド定義をカテゴリ別に整理
- create-pr と git-commit のフローで使う `git switch -c`、`git add`、`git commit --no-gpg-sign`、補助コマンドを追加
- PR 作成やコミット時の不要な確認を減らせるように Codex の default rules を拡張

## テスト計画
- [x] `nixfmt modules/codex.nix`

🤖 Generated with Codex
