### PR TITLE
docs: AGENTS.md の役割を変更ガイド中心に整理

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,101 +1,72 @@
 # AGENTS.md for Dotfiles
 
-このドキュメントは、この dotfiles リポジトリの運用ルール、技術選定、およびコーディング規約を定義するものです。
-AI アシスタントは、コードの生成や変更の提案を行う際、以下のガイドラインに従ってください。
+この文書は、この dotfiles リポジトリに対して AI Agent が安全に変更を加えるための運用ルールを定義するものです。
+完全なディレクトリツリーや実装詳細の網羅はここでは管理しません。最新の構造や実装は、コード、各ディレクトリの README、生成物を正本としてください。
 
-## 1. プロジェクト概要と技術スタック
-- **目的**: Linux (Ubuntu / WSL) 環境におけるユーザー設定 (dotfiles) の管理とセットアップ自動化。
-- **コアツール**: [home-manager](https://github.com/nix-community/home-manager) (ファイル管理・パッケージ管理)
+## 1. プロジェクト概要
+- **目的**: Linux (Ubuntu / WSL) 環境におけるユーザー設定の管理とセットアップ自動化
+- **コアツール**: [home-manager](https://github.com/nix-community/home-manager)
 - **メインシェル**: zsh
 - **CI/CD**: GitHub Actions
-- **ターゲットOS**: Linux (特に Ubuntu および Windows Subsystem for Linux)
+- **ターゲット OS**: Linux、特に Ubuntu および Windows Subsystem for Linux
 
-## 2. 基本原則
-1.  **冪等性の徹底**:
+## 2. 正本
+- **Home Manager の設定と配備定義**: `home.nix`, `modules/`
+- **配備される設定ファイル本体**: `config/`
+- **repo ローカルの共有 AI skill**: `.agents/skills/`
+- **home-manager 配備対象の AI skill / agent 設定**: `config/agents/`, `config/claude/`
+- **Codex / Claude の配備定義**: `modules/codex.nix`, `modules/claude.nix`
+- **セットアップ処理**: `install/`
+- **CI と検証要件の実装**: `.github/workflows/`
+
+## 3. 変更ガイド
+- **Home Manager の挙動や有効化設定を変える**: `home.nix` と `modules/` を確認する
+- **配備される設定ファイルの中身を変える**: `config/` を確認する
+- **shell 関連を変える**: `modules/shell.nix` と対応する `config/` 配下を確認する
+- **Git 設定を変える**: `modules/git.nix` を確認する
+- **GPG / SSH 関連を変える**: `modules/gpg.nix`, `modules/ssh.nix` を確認する
+- **Codex / Claude / AI Agent 設定を変える**: `modules/codex.nix`, `modules/claude.nix`, `.agents/skills/`, `config/agents/`, `config/claude/` のどれが正本かを確認する
+- **セットアップ処理を変える**: `install/` を確認する。定常設定であれば Nix に寄せられないか先に検討する
+- **npm/pnpm パッケージ管理を変える**: `modules/npm/default.nix` と `modules/npm/packages/` を確認する
+- **カスタム package を変える**: `modules/packages/default.nix` と `modules/packages/` を確認する
+- **カスタム script を追加・変更する**: `modules/scripts/default.nix` と `modules/scripts/` を確認する
+- **CI を変える**: `.github/workflows/` を確認する
+
+## 4. 変更ルール
+1. **冪等性を保つ**:
     - `home-manager switch` は何度実行しても安全で、常に同じ結果になる必要があります。
-    - セットアップスクリプトは、処理を行う前に「すでにインストール済みか」「設定済みか」を必ずチェックしてください。
-2.  **宣言的な管理**:
-    - 命令的なシェルスクリプトよりも、`nix/home.nix` での宣言的な設定を優先します。
-    - 環境ごとの微細な差異は、スクリプトの `if` 分岐ではなく、Nix の条件式を使用して吸収してください。
-3.  **シークレットの分離**:
-    - **重要**: 秘密鍵、APIトークン、パスワードなどは**絶対にリポジトリにコミットしないでください**。
-4.  **テスト容易性**:
-    - スクリプトは CI 環境でもエラーなく動作するように記述してください（例: `sudo` がない環境や、対話モードが使えない環境への配慮）。
-## 3. ディレクトリ構造 (Directory Structure)
+    - セットアップスクリプトは、処理前に「すでにインストール済みか」「設定済みか」を必ず確認してください。
+2. **宣言的な管理を優先する**:
+    - 命令的なシェルスクリプトよりも、Nix による宣言的な設定を優先してください。
+    - 環境ごとの微細な差異は、スクリプトの `if` 分岐ではなく、Nix の条件式で吸収してください。
+3. **シークレットを分離する**:
+    - 秘密鍵、API トークン、パスワードなどは絶対にリポジトリへコミットしないでください。
+4. **CI / 非対話環境で動作するようにする**:
+    - スクリプトは CI 環境でもエラーなく動作するように記述してください。
+    - `sudo` がない環境や対話モードが使えない環境を考慮してください。
+5. **追加・移動時は入口と参照先を確認する**:
+    - 新しい module / script / skill / workflow を追加した場合は、対応する入口や参照先も確認してください。
+    - rename / move を行う場合は、関連 README、参照リンク、CI 設定への影響を確認してください。
+6. **AI Agent 設定の置き場所を混同しない**:
+    - `.agents/skills/` は repo ローカルの共有定義です。
+    - `config/agents/skills/` は home-manager 配備対象の定義です。
+    - `config/claude/` は Claude Code の配備内容で、`modules/claude.nix` がその配置を管理します。
 
-- **ディレクトリ構成詳細**:
-    - **`flake.nix`**: フレーク定義。
-    - **`home.nix`**: ホームディレクトリの設定・パッケージ管理。ここで `home.file` を使って `config/` 以下のファイルを配置します。
-    - **`modules/`**: 機能別に分割された Nix モジュール。
-        - `packages.nix`: コアパッケージ
-        - `git.nix`: Git 設定・GPG 署名・gh 認証情報ヘルパー
-        - `gpg.nix`: GPG/SSH キーを Doppler から取得・設定 (CI 時はスキップ)
-        - `ssh.nix`: SSH キー管理モジュール
-        - `shell.nix`: zsh・starship・direnv・cargo・pnpm パス設定
-        - `codex.nix`: Codex CLI の `config.toml` と `default.rules` 配置
-        - `claude.nix`: `config/claude/` を `~/.claude/` に配置
-        - `gitleaks.nix`: gitleaks パッケージ
-        - `npm/default.nix` + `npm/packages/`: npm/pnpm パッケージの動的管理
-        - `packages/default.nix` + `packages/`: カスタムパッケージの動的管理
-        - `scripts/default.nix` + `scripts/`: カスタムシェルスクリプト管理
-    - **`config/`**: home-manager が配置する生ファイル群。
-        - `zshrc`, `zprofile`: シェル設定。
-        - `git/hooks/pre-commit`: Git フック (gitleaks によるシークレット検出)。
-        - `agents/skills/`: home-manager 配備用の AI スキル定義。
-        - `claude/`: Claude Code 設定。
-            - `hooks/notify.sh`: WSL 向け Windows Toast 通知スクリプト。
-            - `settings.json`: フック・プラグイン設定。
-    - **`.agents/`**: エージェント横断で使うローカル AI 定義。
-        - `skills/`: Codex / Claude / Copilot で共有するスキル定義。
-    - **`.claude/`**: ローカル開発用 Claude Code 設定。
-        - `agents/`: Claude 用カスタムエージェント定義。
-        - `skills/`: `../.agents/skills` を指す互換用シンボリックリンク。
-        - `worktrees/`: ワークツリー管理。
-    - **`install/`**: (Bootstrap & Setup) セットアップ用スクリプト置き場。
-        - `setup.sh`: エントリーポイント。OS を検出して以下のスクリプトを順に呼び出す。
-        - `common/`: ディストリビューションに依存しない共通処理。
-        - `ubuntu/`: Ubuntu / Debian 系固有の処理。
-    - **`templates/`**: 開発環境テンプレート。
-    - **`.githooks/`**: ローカル git フック。
-        - `install/common/setup-local-hooks.sh` で登録セットアップされている。
+## 5. ドキュメント方針
+- 完全なディレクトリツリーはこの文書に記載しない
+- ファイル一覧やサブディレクトリ一覧を手書きで維持しない
+- 頻繁に変わる詳細は、各ディレクトリ README または生成可能な一覧に委ねる
+- この文書には、方針、責務、正本、変更判断基準のみを記載する
 
-## 3.1. AI Agent 設定について
+## 6. 検証要件
+- **`.nix` ファイル変更後**: `nixfmt` を適用する
+- **シェルスクリプト変更後**: `shellcheck` を通す
+- **Home Manager に影響する変更後**: `home-manager build --flake .#testuser` を確認する
+- **シークレット検出**: `gitleaks` を前提とする
+- **ドキュメント参照先を変更した場合**: リンクや整合性チェックを通す
 
-AI Agent 関連の設定は複数の配置先に分かれています。
-
-- **`config/agents/skills/`**: home-manager 配備対象の Claude Code 向けスキル定義の正規配置。
-- **`.agents/skills/`**: リポジトリローカルの共通スキル定義。
-- **`modules/codex.nix`**: `~/.codex/config.toml` と `~/.codex/rules/default.rules` の配備定義。
-- **`config/claude/settings.json`**: Claude Code の hooks と permission を含む実効設定。
-
-`config/` 配下の詳細な編集ルールは `config/AGENTS.md`、各ディレクトリの仕様は `config/README.md` と配下の README を参照してください。
-
-## 3.2. Renovate / CI ワークフローについて
-
-- `.github/workflows/lint.yaml`: shellcheck・nixfmt Lint を実行。
-- `.github/workflows/integration-test.yaml`: Cachix を使った `home-manager build` によるビルド検証を実行。
-- `.github/workflows/nix.yaml`: `nix flake check` を実行。
-- `.github/workflows/nix-update-pr.yaml`: Renovate が npm パッケージバージョンを上げた際、pnpm ハッシュを自動再計算してコミット。
-- `.github/workflows/update-flake-lock.yaml`: 週次で `flake.lock` を更新する PR を自動作成。
-- `.github/workflows/renovate.yaml`: Renovate ボット設定。
-- `.github/workflows/e2e-setup-test.yaml`: ubuntu-24.04 でのセットアップ E2E テスト。
-
-## 4. CI/CD と検証ガイドライン
-- **Lint**:
-    - すべてのシェルスクリプトは `shellcheck` をパスすること。
-    - すべての `.nix` ファイルは `nixfmt` でフォーマットされていること。コード変更後は `nixfmt <file>` を実行してフォーマットを適用してください。
-- **Integration Test**:
-    - CI パイプラインでは GitHub Actions + Cachix を使い、`home-manager build --flake .#testuser` を実行してビルドエラーがないかを確認する。
-
-## 4.1. 取り込み要件 (Merge Requirements)
-PR をマージする前に、以下がすべてパスしていることを確認してください：
-1. **nixfmt**: すべての `.nix` ファイルが `nixfmt` でフォーマット済みであること。
-2. **shellcheck**: すべてのシェルスクリプトが `shellcheck` をパスしていること。
-3. **home-manager build**: `home-manager build --flake .#testuser` がエラーなく完了すること（CI で Cachix を使用）。
-4. **gitleaks**: シークレット検出は `gitleaks` で実行（pre-commit フックおよび CI で実行）。
-
-## 5. 管理対象コンポーネント
-このリポジトリで管理すべき主な対象：
-- **Shell**: `.zshrc`, `.zprofile`
-- **Git**: `.gitconfig` (`programs.git` で管理), `.gitignore` (グローバル設定)
-- **WSL固有**: `wsl.conf` 等が必要な場合は、OS 判定ロジックを用いて管理する。
+## 7. ディレクトリ別の参照先
+- `config/` 配下の詳細な編集ルールは `config/AGENTS.md` を参照してください
+- Claude 関連の詳細は `config/claude/AGENTS.md`, `config/claude/README.md` を参照してください
+- agents 配下の詳細は `config/agents/AGENTS.md`, `config/agents/skills/README.md` を参照してください
+- 実装の全体像や詳細一覧が必要な場合は、まずコードと生成物を確認してください


### PR DESCRIPTION
## 概要
- `AGENTS.md` から詳細なディレクトリツリーや網羅列挙を削除し、腐りやすい静的構成説明を減らしました
- `正本`、`変更ガイド`、`変更ルール`、`検証要件` を中心に再構成し、AI Agent が変更時の入口を判断しやすい形に整理しました
- 章タイトルを日本語に統一し、詳細ルールは各ディレクトリ配下の文書を参照する構成に寄せました

## 確認事項
- `AGENTS.md` の本文を見直し、主要な変更導線と既存の重要ルールが残っていることを確認しました
- ドキュメント変更のみのため、`nixfmt`、`shellcheck`、`home-manager build` は実行していません
- コミット前フックの `gitleaks` は通過し、シークレット混入がないことを確認しました

## 補足
- CI 側のリンク検査や整合性チェックはこの PR では追加していません

🤖 Generated with Codex