### PR TITLE
feat: yazi で隠しファイルを表示する

### DIFF
--- a/config/yazi/yazi.toml
+++ b/config/yazi/yazi.toml
@@ -1,0 +1,2 @@
+[manager]
+show_hidden = true

--- a/home.nix
+++ b/home.nix
@@ -11,6 +11,7 @@
     ./modules/gpg.nix
     ./modules/ssh.nix
     ./modules/shell.nix
+    ./modules/yazi.nix
     ./modules/scripts
     ./modules/agents.nix
     ./modules/codex.nix

--- a/modules/yazi.nix
+++ b/modules/yazi.nix
@@ -1,0 +1,4 @@
+{ ... }:
+{
+  xdg.configFile."yazi/yazi.toml".source = ../config/yazi/yazi.toml;
+}


### PR DESCRIPTION
## 概要
- Yazi の設定ファイルを home-manager 管理に追加し、`~/.config/yazi/yazi.toml` を配備するようにしました
- `[manager] show_hidden = true` を設定し、隠しファイルを常時表示するようにしました
- `home.nix` に Yazi 用 module を追加し、既存の配備フローに組み込みました

## 確認事項
- `nixfmt home.nix modules/yazi.nix` を実行し、追加した `.nix` ファイルの整形を確認しました
- `home-manager build --flake .#testuser` を実行し、設定全体が評価・ビルドできることを確認しました

🤖 Generated with Codex