### PR TITLE
fix: yazi 設定のセクション名を修正する

### DIFF
--- a/config/yazi/yazi.toml
+++ b/config/yazi/yazi.toml
@@ -1,2 +1,2 @@
-[manager]
+[mgr]
 show_hidden = true


### PR DESCRIPTION
## 概要
- 前回追加した Yazi の隠しファイル表示設定が効いていなかったため、設定セクション名を `[manager]` から `[mgr]` に修正しました
- Yazi 26.1.22 の設定形式に合わせ、`show_hidden = true` が正しく読み込まれる状態にしました

## 確認事項
- `~/.config/yazi/yazi.toml` に前回の設定が配備されていることを確認したうえで、セクション名が誤っていたことを特定しました
- `home-manager build --flake .#testuser` を実行し、修正後の設定でも Home Manager 全体が正常に評価・ビルドできることを確認しました

## 補足
- これは PR #280 の follow-up 修正です

🤖 Generated with Codex