### PR TITLE
refactor: yazi 設定を Nix で宣言的に管理する

### DIFF
--- a/config/yazi/yazi.toml
+++ b/config/yazi/yazi.toml
@@ -1,2 +1,0 @@
-[mgr]
-show_hidden = true

--- a/modules/yazi.nix
+++ b/modules/yazi.nix
@@ -1,4 +1,4 @@
 { ... }:
 {
-  xdg.configFile."yazi/yazi.toml".source = ../config/yazi/yazi.toml;
+  programs.yazi.settings.mgr.show_hidden = true;
 }


### PR DESCRIPTION
## 概要
- yazi の設定を config/yazi/yazi.toml から modules/yazi.nix の `programs.yazi.settings` で管理するようにした
- 宣言的な Nix 管理により、home-manager が設定の完全な状態を管理できるようになった
- 設定ファイルの重複管理が不要になった

## 確認事項
- `home-manager build --flake .#testuser` で正常にビルドすることを確認
- 配備される yazi の設定は従来と同一（show_hidden = true）であることを確認

🤖 Generated with Claude Code