### PR TITLE
deps: neovim を追加する

### DIFF
--- a/modules/git.nix
+++ b/modules/git.nix
@@ -26,7 +26,7 @@
       gpg.program = "gpg";
       init.defaultBranch = "main";
       core = {
-        editor = "vim";
+        editor = "nvim";
         hooksPath = "~/.config/git/hooks";
       };
       "credential \"https://github.com\"".helper = [

--- a/modules/packages.nix
+++ b/modules/packages.nix
@@ -5,6 +5,7 @@
     jq
     direnv
     starship
+    neovim
     nixfmt
     doppler
     gh


### PR DESCRIPTION
## 概要
- Home Manager の共通パッケージに `neovim` を追加し、環境へ配備されるようにしました
- Git の `core.editor` を `nvim` に変更し、追加したエディタをそのまま利用する設定に揃えました
- 影響範囲は dotfiles の Home Manager 設定と Git 設定です

## 確認事項
- `nixfmt modules/packages.nix modules/git.nix` を実行し、変更した `.nix` ファイルを整形しました
- `home-manager build --flake .#testuser` を実行し、`neovim` を含む構成で Home Manager の生成が成功することを確認しました
- `programs.git.signing.format` に関する既存 warning は出ますが、今回の変更によるビルド失敗はありません

🤖 Generated with Codex