### PR TITLE
feat: Neovim 設定と GitHub Copilot を追加する

### DIFF
--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -1,0 +1,2 @@
+vim.opt.number = true
+vim.opt.relativenumber = true

--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -1,2 +1,17 @@
 vim.opt.number = true
 vim.opt.relativenumber = true
+
+local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+if not vim.loop.fs_stat(lazypath) then
+  vim.fn.system({
+    "git",
+    "clone",
+    "--filter=blob:none",
+    "https://github.com/folke/lazy.nvim.git",
+    "--branch=stable",
+    lazypath,
+  })
+end
+vim.opt.rtp:prepend(lazypath)
+
+require("lazy").setup("plugins")

--- a/config/nvim/lua/plugins/copilot.lua
+++ b/config/nvim/lua/plugins/copilot.lua
@@ -1,0 +1,12 @@
+return {
+  {
+    "github/copilot.vim",
+    cmd = "Copilot",
+    event = "InsertEnter",
+    init = function()
+      vim.g.copilot_filetypes = {
+        ["*"] = true,
+      }
+    end,
+  },
+}

--- a/home.nix
+++ b/home.nix
@@ -10,6 +10,7 @@
     ./modules/git.nix
     ./modules/gpg.nix
     ./modules/ssh.nix
+    ./modules/neovim.nix
     ./modules/shell.nix
     ./modules/yazi.nix
     ./modules/scripts

--- a/modules/neovim.nix
+++ b/modules/neovim.nix
@@ -1,0 +1,4 @@
+{ ... }:
+{
+  xdg.configFile."nvim/init.lua".source = ../config/nvim/init.lua;
+}

--- a/modules/packages.nix
+++ b/modules/packages.nix
@@ -6,6 +6,7 @@
     direnv
     starship
     neovim
+    nodejs_24
     nixfmt
     doppler
     gh


### PR DESCRIPTION
## 概要
- dotfiles 配下で Neovim 設定を管理できるようにし、`config/nvim/init.lua` を Home Manager 経由で `~/.config/nvim/init.lua` へ配備するようにしました
- Neovim では絶対行番号と相対行番号を有効化し、Lua 正本のまま `lazy.nvim` と `github/copilot.vim` を導入できる構成を追加しました
- Copilot の実行前提を満たすため、Home Manager で導入する Node.js を `nodejs_24` に固定しました

## 確認事項
- `nixfmt` を適用し、追加した Nix 変更の整形が崩れていないことを確認しました
- `home-manager build --flake .#testuser` を実行し、Neovim 設定配備と Copilot 用の Node.js 24 追加を含む Home Manager ビルドが通ることを確認しました
- Neovim 起動後の初回 `:Copilot setup` 認証までは未確認です。plugin の取得と GitHub 認証が必要なため、実機での初回セットアップ確認をお願いします

## 補足
- Copilot plugin 自体は `lazy.nvim` の bootstrap により初回起動時に取得する構成です

🤖 Generated with Codex