### PR TITLE
fix: Neovim の Copilot 初期化エラーを修正する

### DIFF
--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -1,8 +1,11 @@
 vim.opt.number = true
 vim.opt.relativenumber = true
 
+local uv = vim.uv or vim.loop
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
-if not vim.loop.fs_stat(lazypath) then
+local lazy_init = lazypath .. "/lua/lazy/init.lua"
+
+if not uv.fs_stat(lazy_init) then
   vim.fn.system({
     "git",
     "clone",
@@ -12,6 +15,13 @@ if not vim.loop.fs_stat(lazypath) then
     lazypath,
   })
 end
-vim.opt.rtp:prepend(lazypath)
 
+if not uv.fs_stat(lazy_init) then
+  vim.schedule(function()
+    vim.notify("lazy.nvim の取得に失敗しました。:checkhealth とネットワーク状態を確認してください。", vim.log.levels.ERROR)
+  end)
+  return
+end
+
+vim.opt.rtp:prepend(lazypath)
 require("lazy").setup("plugins")

--- a/modules/neovim.nix
+++ b/modules/neovim.nix
@@ -1,4 +1,4 @@
 { ... }:
 {
-  xdg.configFile."nvim/init.lua".source = ../config/nvim/init.lua;
+  xdg.configFile."nvim".source = ../config/nvim;
 }


### PR DESCRIPTION
## 概要
- `lazy.nvim` の bootstrap が不完全な状態でも `require("lazy")` に進んで落ちないよう、取得結果を確認してから初期化するようにしました
- Home Manager の Neovim 配備対象を `init.lua` 単体から `config/nvim` ディレクトリ全体に変更し、`lua/plugins/copilot.lua` も実際に `~/.config/nvim` へ配備されるようにしました
- これにより `module 'lazy' not found` と `No specs found for module "plugins"` の両方を防ぐ構成にしています

## 確認事項
- `home-manager build --flake .#testuser` を実行し、Neovim 設定ディレクトリ全体の配備へ変更した後も Home Manager ビルドが通ることを確認しました
- ローカルでは不完全な `lazy.nvim` checkout を復旧し、`init.lua` の防御追加後に `module 'lazy' not found` の原因が bootstrap 不全だったことを確認しました
- `nvim --headless` の完全な起動確認はこの実行環境では `~/.cache/nvim` への書き込み制約に阻まれるため未完了です。通常環境で `home-manager switch` 後に Neovim を開いて確認してください

## 補足
- ワークツリーには `nvim.log` が未追跡で残っていますが、今回の PR には含めていません

🤖 Generated with Codex