### PR TITLE
Neovim の Lua 構文検証を CI に追加する

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -31,9 +31,16 @@ jobs:
       - name: Install shellcheck
         run: sudo apt-get install -y shellcheck
 
+      - name: Install Lua
+        run: sudo apt-get install -y lua5.4
+
       - name: Run shellcheck
         run: |
           find . -type f \( -name "*.sh" -o ! -name "*.*" \) \
             | xargs grep -lE '^#!.*\b(bash|sh)\b' \
             | xargs shellcheck
 
+      - name: Check Neovim Lua syntax
+        run: |
+          find config/nvim -type f -name "*.lua" -print0 \
+            | xargs -0 -n1 luac5.4 -p


### PR DESCRIPTION
## 概要
- `config/nvim` 配下の Lua 設定に対する静的検証が CI に存在していなかったため、`Lint` workflow に構文チェックを追加しました
- GitHub Actions 上で `lua5.4` をインストールし、`luac5.4 -p` で Neovim 設定ファイルの構文崩れを検出できるようにしました
- 既存の shellcheck や gitleaks と同じ lint 系 CI に載せることで、設定変更時の早いフィードバックを狙っています

## 確認事項
- 変更内容を確認し、`.github/workflows/lint.yaml` に Lua インストールと `config/nvim/**/*.lua` への構文チェックが追加されていることを確認しました
- ローカルでは `luac5.4` が入っていなかったため、追加したチェックコマンド自体の実行確認はしていません。実行結果の確認は GitHub Actions 上の CI に委ねています

## 補足
- Neovim の実起動確認はまだ追加していません。必要であれば、既存の E2E setup test に `nvim --headless` の smoke test を足す余地があります

🤖 Generated with Codex