### PR TITLE
fix: Neovim のシンタックスハイライトを有効化

### DIFF
--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -1,5 +1,9 @@
 vim.opt.number = true
 vim.opt.relativenumber = true
+vim.opt.termguicolors = true
+
+vim.cmd("syntax enable")
+vim.cmd("filetype plugin indent on")
 
 local uv = vim.uv or vim.loop
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"


### PR DESCRIPTION
## 概要
- Neovim の初期設定で `termguicolors` を有効にし、色付きハイライトを表示できるようにしました。
- `syntax enable` と `filetype plugin indent on` を追加し、配備直後から組み込みのシンタックスハイライトと filetype ごとの基本設定が有効になるようにしました。
- アーカイブ済みの `nvim-treesitter` には依存せず、Neovim 組み込み機能だけで完結する変更です。

## 確認事項
- `home-manager build --flake .#testuser` を実行し、この変更で Home Manager のビルドが通ることを確認しました。
- ビルド時に `programs.git.signing.format` の既存警告と Home Manager news の案内は出ていますが、今回の変更に起因するエラーはありません。
- `nvim --headless` の確認は sandbox 制約と初回プラグイン処理待ちの影響で十分に追い切れていませんが、変更は `init.lua` への単純な組み込み設定追加に限定しています。

🤖 Generated with Codex