### PR TITLE
fix: Neovim の Markdown ハイライトを見やすくする

### DIFF
--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -1,6 +1,9 @@
 vim.opt.number = true
 vim.opt.relativenumber = true
 vim.opt.termguicolors = true
+vim.opt.cursorline = true
+vim.opt.signcolumn = "yes"
+vim.opt.conceallevel = 2
 
 vim.cmd("syntax enable")
 vim.cmd("filetype plugin indent on")
@@ -29,3 +32,24 @@ end
 
 vim.opt.rtp:prepend(lazypath)
 require("lazy").setup("plugins")
+
+vim.cmd.colorscheme("gruvbox")
+
+local markdown_highlights = vim.api.nvim_create_augroup("markdown_highlights", { clear = true })
+
+vim.api.nvim_create_autocmd("ColorScheme", {
+  group = markdown_highlights,
+  callback = function()
+    vim.api.nvim_set_hl(0, "markdownH1", { fg = "#fb4934", bold = true })
+    vim.api.nvim_set_hl(0, "markdownH2", { fg = "#fe8019", bold = true })
+    vim.api.nvim_set_hl(0, "markdownH3", { fg = "#fabd2f", bold = true })
+    vim.api.nvim_set_hl(0, "markdownCode", { fg = "#b8bb26", italic = true })
+    vim.api.nvim_set_hl(0, "markdownCodeBlock", { fg = "#b8bb26" })
+    vim.api.nvim_set_hl(0, "markdownLinkText", { fg = "#83a598", underline = true })
+    vim.api.nvim_set_hl(0, "markdownUrl", { fg = "#8ec07c", underline = true })
+    vim.api.nvim_set_hl(0, "markdownBold", { bold = true })
+    vim.api.nvim_set_hl(0, "markdownItalic", { italic = true })
+  end,
+})
+
+vim.api.nvim_exec_autocmds("ColorScheme", { group = markdown_highlights })

--- a/config/nvim/lua/plugins/editor.lua
+++ b/config/nvim/lua/plugins/editor.lua
@@ -1,0 +1,21 @@
+return {
+  {
+    "ellisonleao/gruvbox.nvim",
+    priority = 1000,
+    opts = {
+      contrast = "hard",
+      transparent_mode = false,
+    },
+  },
+  {
+    "preservim/vim-markdown",
+    ft = { "markdown" },
+    init = function()
+      vim.g.vim_markdown_conceal = 0
+      vim.g.vim_markdown_conceal_code_blocks = 0
+      vim.g.vim_markdown_frontmatter = 1
+      vim.g.vim_markdown_folding_disabled = 1
+      vim.g.vim_markdown_strikethrough = 1
+    end,
+  },
+}


### PR DESCRIPTION
## 概要
- Neovim に `gruvbox` と `vim-markdown` を追加し、Markdown でも構文ごとの差が見える配色に調整
- `cursorline`、`signcolumn`、`conceallevel` と Markdown 用ハイライトを加えて、見出し・コード・リンクの視認性を上げる
- `nvim-treesitter` は使わず、現在の前提に合わせて標準 syntax と Markdown プラグインで完結させる

## 確認事項
- `home-manager build --flake .#testuser` が成功し、Home Manager 配備定義として破綻していないことを確認
- `nvim --headless` は sandbox では `lazy.nvim` の初回取得に失敗したため、プラグインの初回取得は実環境での起動に依存する
- `nvim.log` は PR に含めていない

🤖 Generated with Codex