### PR TITLE
chore: .log ファイルを Git 管理から除外する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 result
+.log


### PR DESCRIPTION
## 概要
- `.gitignore` に `.log` を追加し、実行時に生成されるログファイルが作業ツリーに混ざらないようにしました。
- 変更範囲は ignore 設定 1 行のみで、既存設定や配備ロジックには影響しません。

## 確認事項
- `git diff main...HEAD --stat` で `.gitignore` の 1 行追加だけが PR に含まれることを確認しました。
- ignore ルールの追加のみで実行時挙動は変わらないため、追加のビルドやテストは実施していません。

🤖 Generated with Codex