### PR TITLE
fix: Neovim の配色を青系テーマへ変更する

### DIFF
--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -33,20 +33,20 @@ end
 vim.opt.rtp:prepend(lazypath)
 require("lazy").setup("plugins")
 
-vim.cmd.colorscheme("gruvbox")
+vim.cmd.colorscheme("tokyonight")
 
 local markdown_highlights = vim.api.nvim_create_augroup("markdown_highlights", { clear = true })
 
 vim.api.nvim_create_autocmd("ColorScheme", {
   group = markdown_highlights,
   callback = function()
-    vim.api.nvim_set_hl(0, "markdownH1", { fg = "#fb4934", bold = true })
-    vim.api.nvim_set_hl(0, "markdownH2", { fg = "#fe8019", bold = true })
-    vim.api.nvim_set_hl(0, "markdownH3", { fg = "#fabd2f", bold = true })
-    vim.api.nvim_set_hl(0, "markdownCode", { fg = "#b8bb26", italic = true })
-    vim.api.nvim_set_hl(0, "markdownCodeBlock", { fg = "#b8bb26" })
-    vim.api.nvim_set_hl(0, "markdownLinkText", { fg = "#83a598", underline = true })
-    vim.api.nvim_set_hl(0, "markdownUrl", { fg = "#8ec07c", underline = true })
+    vim.api.nvim_set_hl(0, "markdownH1", { fg = "#7aa2f7", bold = true })
+    vim.api.nvim_set_hl(0, "markdownH2", { fg = "#7dcfff", bold = true })
+    vim.api.nvim_set_hl(0, "markdownH3", { fg = "#89ddff", bold = true })
+    vim.api.nvim_set_hl(0, "markdownCode", { fg = "#73daca", italic = true })
+    vim.api.nvim_set_hl(0, "markdownCodeBlock", { fg = "#73daca" })
+    vim.api.nvim_set_hl(0, "markdownLinkText", { fg = "#7aa2f7", underline = true })
+    vim.api.nvim_set_hl(0, "markdownUrl", { fg = "#2ac3de", underline = true })
     vim.api.nvim_set_hl(0, "markdownBold", { bold = true })
     vim.api.nvim_set_hl(0, "markdownItalic", { italic = true })
   end,

--- a/config/nvim/lua/plugins/editor.lua
+++ b/config/nvim/lua/plugins/editor.lua
@@ -1,10 +1,10 @@
 return {
   {
-    "ellisonleao/gruvbox.nvim",
+    "folke/tokyonight.nvim",
     priority = 1000,
     opts = {
-      contrast = "hard",
-      transparent_mode = false,
+      style = "night",
+      transparent = false,
     },
   },
   {


### PR DESCRIPTION
## 概要
- Neovim のカラースキームを `gruvbox` から `tokyonight` に切り替え、全体の配色を青系へ変更
- Markdown の見出し、コード、リンクのハイライト色も青系のトーンへ揃えて、テーマ変更後の見た目を統一
- 影響範囲は `config/nvim/` 配下の Neovim 設定のみ

## 確認事項
- `home-manager build --flake .#testuser` を実行し、Home Manager の構成がこの変更を含めて正常にビルドできることを確認
- ビルド時に既存の evaluation warning は出るが、今回の Neovim 設定変更に起因するエラーは発生していないことを確認

🤖 Generated with Codex
