### PR TITLE
fix: Neovim で絶対番号と相対番号を同時表示する

### DIFF
--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -3,7 +3,21 @@ vim.opt.relativenumber = true
 vim.opt.termguicolors = true
 vim.opt.cursorline = true
 vim.opt.signcolumn = "yes"
+vim.opt.numberwidth = 4
 vim.opt.conceallevel = 2
+
+function _G.statuscolumn_numbers()
+  if vim.v.virtnum ~= 0 then
+    return ""
+  end
+
+  local absolute = tostring(vim.v.lnum)
+  local relative = tostring(vim.v.relnum)
+
+  return string.format("%4s %4s ", absolute, relative)
+end
+
+vim.opt.statuscolumn = "%s%=%{v:lua.statuscolumn_numbers()}"
 
 vim.cmd("syntax enable")
 vim.cmd("filetype plugin indent on")


### PR DESCRIPTION
## 概要
- Neovim の行番号表示を `statuscolumn` ベースに切り替え、各行に絶対番号と相対番号を併記するように変更
- `number` と `relativenumber` を併用した上で、現在行だけ絶対番号になる標準表示ではなく全行で絶対番号を見られるように調整
- 変更範囲は `config/nvim/init.lua` のみで、Home Manager で配備される Neovim 設定に限定

## 確認事項
- `git diff main...HEAD --stat` で PR の変更範囲が `config/nvim/init.lua` のみに収まっていることを確認
- `git status --short --branch` でコミット後の作業ツリーがクリーンで、`fix/neovim-dual-line-numbers` ブランチ上の変更だけが含まれることを確認
- Lua の構文チェック用ランタイム (`lua` / `luac`) はこの環境に入っておらず未実施。設定変更のみのため差分確認を優先しており、実際の表示は Neovim 起動時にレビューで確認してほしい

## 補足
- `statuscolumn` を使った表示にしているため、行番号列の幅や並びを変えたい場合は `string.format` の桁数で調整可能

🤖 Generated with Codex