### PR TITLE
feat: Neovim に blink.cmp を追加

### DIFF
--- a/config/nvim/lua/plugins/completion.lua
+++ b/config/nvim/lua/plugins/completion.lua
@@ -1,0 +1,33 @@
+return {
+  {
+    "saghen/blink.cmp",
+    lazy = false,
+    version = "1.*",
+    dependencies = {
+      "rafamadriz/friendly-snippets",
+    },
+    opts = {
+      appearance = {
+        nerd_font_variant = "mono",
+      },
+      completion = {
+        documentation = {
+          auto_show = false,
+        },
+      },
+      cmdline = {
+        keymap = {
+          preset = "inherit",
+        },
+        completion = {
+          menu = {
+            auto_show = true,
+          },
+        },
+      },
+      fuzzy = {
+        implementation = "lua",
+      },
+    },
+  },
+}


### PR DESCRIPTION
## 概要
- Neovim の補完基盤として `saghen/blink.cmp` を追加し、通常入力とコマンドライン補完を 1 つの plugin で使えるようにしました。
- cmdline の補完メニューは自動表示にして、`:Buffer` などのコマンド入力時に候補がすぐ見えるようにしました。
- 追加のネイティブバイナリ取得に依存しないよう、fuzzy 実装は Lua を使う設定にしています。

## 確認事項
- `home-manager build --flake .#testuser` が成功し、Home Manager 配備対象として設定が評価できることを確認しました。
- `nvim --headless --clean` で `config/nvim/lua/plugins/completion.lua` を読み込み、Lua として解釈できることを確認しました。
- `blink.cmp` の実際の UI 操作確認は未実施です。初回起動時に `lazy.nvim` が plugin を取得したあと、挿入モード補完と `:` 補完の動作を確認してください。

🤖 Generated with Codex