### PR TITLE
feat: add Telescope navigation keymaps

### DIFF
--- a/config/nvim/lua/plugins/navigation.lua
+++ b/config/nvim/lua/plugins/navigation.lua
@@ -17,6 +17,12 @@ return {
     dependencies = {
       "nvim-lua/plenary.nvim",
     },
+    keys = {
+      { "<C-p>", "<Cmd>Telescope find_files<CR>", desc = "Find files" },
+      { "<Leader>fb", "<Cmd>Telescope buffers<CR>", desc = "Buffers" },
+      { "<Leader>fr", "<Cmd>Telescope oldfiles<CR>", desc = "Recent files" },
+      { "<Leader>fg", "<Cmd>Telescope live_grep<CR>", desc = "Live grep" },
+    },
     opts = {},
   },
 }


### PR DESCRIPTION
## 概要
- Neovim の Telescope に `Ctrl+P` を割り当て、VSCode に近いファイル検索導線を追加しました。
- あわせてバッファ一覧、最近開いたファイル、live grep を開くキーマップも追加しました。
- 変更対象は `config/nvim/lua/plugins/navigation.lua` のみです。

## 確認事項
- 差分を確認し、Telescope の `keys` に必要なキーマップが追加されていることを確認しました。
- Neovim 上での実操作確認は未実施です。この変更は Lua 設定の追加のみで影響範囲が限定的なため、レビューではキーマップの衝突有無を見てもらえると助かります。

🤖 Generated with Codex
