### PR TITLE
feat: barbar のタブ切り替えキーマップを追加する

### DIFF
--- a/config/nvim/lua/plugins/editor.lua
+++ b/config/nvim/lua/plugins/editor.lua
@@ -13,6 +13,24 @@ return {
     dependencies = {
       "nvim-tree/nvim-web-devicons",
     },
+    keys = {
+      { "<A-,>", "<Cmd>BufferPrevious<CR>", desc = "Previous buffer" },
+      { "<A-.>", "<Cmd>BufferNext<CR>", desc = "Next buffer" },
+      { "<A-<>", "<Cmd>BufferMovePrevious<CR>", desc = "Move buffer left" },
+      { "<A->>", "<Cmd>BufferMoveNext<CR>", desc = "Move buffer right" },
+      { "<A-c>", "<Cmd>BufferClose<CR>", desc = "Close buffer" },
+      { "<A-p>", "<Cmd>BufferPin<CR>", desc = "Pin buffer" },
+      { "<A-1>", "<Cmd>BufferGoto 1<CR>", desc = "Go to buffer 1" },
+      { "<A-2>", "<Cmd>BufferGoto 2<CR>", desc = "Go to buffer 2" },
+      { "<A-3>", "<Cmd>BufferGoto 3<CR>", desc = "Go to buffer 3" },
+      { "<A-4>", "<Cmd>BufferGoto 4<CR>", desc = "Go to buffer 4" },
+      { "<A-5>", "<Cmd>BufferGoto 5<CR>", desc = "Go to buffer 5" },
+      { "<A-6>", "<Cmd>BufferGoto 6<CR>", desc = "Go to buffer 6" },
+      { "<A-7>", "<Cmd>BufferGoto 7<CR>", desc = "Go to buffer 7" },
+      { "<A-8>", "<Cmd>BufferGoto 8<CR>", desc = "Go to buffer 8" },
+      { "<A-9>", "<Cmd>BufferGoto 9<CR>", desc = "Go to buffer 9" },
+      { "<A-0>", "<Cmd>BufferLast<CR>", desc = "Go to last buffer" },
+    },
     init = function()
       vim.g.barbar_auto_setup = false
     end,


### PR DESCRIPTION
## 概要
- barbar.nvim でバッファ切り替えコマンドを毎回入力しなくて済むよう、一般的な Alt 系キーマップを追加しました。
- 前後移動、並び替え、クローズ、ピン留め、番号による直接移動を `config/nvim/lua/plugins/editor.lua` に定義しました。
- 既存の plugin 設定構成は維持しつつ、barbar の操作性だけを局所的に改善しています。

## 確認事項
- 差分を確認し、barbar.nvim の `keys` 定義として自然な形で追加されていることを確認しました。
- Lua ファイル 1 件の設定追加のみで、Nix や配備経路には影響しないため追加のビルド検証は実施していません。
- ターミナル環境によっては Alt キーがそのまま届かない可能性があるため、その場合は別キーへの再割り当てが必要です。

🤖 Generated with Codex