### PR TITLE
fix: Home Manager の既定値変更に伴う warning を解消

### DIFF
--- a/modules/git.nix
+++ b/modules/git.nix
@@ -2,7 +2,10 @@
 {
   programs.git = {
     enable = true;
-    signing = lib.mkIf (personal.gpgKey != "") {
+    signing = {
+      format = "openpgp";
+    }
+    // lib.optionalAttrs (personal.gpgKey != "") {
       key = personal.gpgKey;
       signByDefault = true;
     };

--- a/modules/yazi.nix
+++ b/modules/yazi.nix
@@ -2,6 +2,7 @@
 {
   programs.yazi = {
     enable = true;
+    shellWrapperName = "y";
     settings = {
       mgr.show_hidden = true;
       opener.edit = [


### PR DESCRIPTION
## 概要
- Home Manager の既定値変更で出ていた `programs.yazi.shellWrapperName` の evaluation warning を消すため、yazi のラッパー名を新しい既定値 `y` で明示しました
- `programs.git.signing.format` も `openpgp` を明示し、`personal.gpgKey` が空の環境でも同じ warning が出ないようにしました
- 既存の GPG 鍵利用環境ではこれまで通り `key` と `signByDefault` を有効にし、挙動を維持しています

## 確認事項
- `home-manager build --flake .#testuser` を実行し、`programs.yazi.shellWrapperName` と `programs.git.signing.format` の evaluation warning が出なくなることを確認しました
- ビルド時には別件の Nix 警告として `builtins.derivation` に関する warning は残っていますが、今回の変更に起因するものではありません

## 補足
- `testuser` では `personal.gpgKey` が空のため、`format` を条件外に出さないと warning が消えない構成でした

🤖 Generated with Codex