### PR TITLE
feat: Neovim にコメント切り替えのキーマップを追加する

### DIFF
--- a/config/nvim/lua/plugins/editing.lua
+++ b/config/nvim/lua/plugins/editing.lua
@@ -7,6 +7,12 @@ return {
   {
     "tpope/vim-commentary",
     event = "VeryLazy",
+    keys = {
+      { "<C-/>", "<Cmd>Commentary<CR>", mode = "n", desc = "Toggle comment" },
+      { "<C-_>", "<Cmd>Commentary<CR>", mode = "n", desc = "Toggle comment" },
+      { "<C-/>", "<Plug>Commentary", mode = "x", desc = "Toggle comment" },
+      { "<C-_>", "<Plug>Commentary", mode = "x", desc = "Toggle comment" },
+    },
   },
   {
     "pocco81/auto-save.nvim",


### PR DESCRIPTION
## 概要
- Neovim の `vim-commentary` に `Ctrl+/` でコメント切り替えできるキーマップを追加しました
- 通常モードでは現在行、Visual mode では選択範囲を対象にコメント切り替えを呼び出します
- 端末によって `Ctrl+/` が `Ctrl+_` として届くケースに備えて両方を受けるようにしています

## 確認事項
- `home-manager build --flake .#testuser` を実行し、この設定変更を含む Home Manager のビルドが成功することを確認しました
- 実際の `Ctrl+/` 入力での手動確認は未実施です。端末側のキー送出差異はあるため、必要ならレビュー環境で `Ctrl+/` と `Ctrl+_` の両方を確認してください

## 補足
- `nvim --headless` での追加確認は sandbox 環境の state/cache 書き込み制限に当たるため、今回の検証は Home Manager ビルド成功を基準にしています

🤖 Generated with Codex