### PR TITLE
fix: WSL GUI 向けの Noto フォント設定を追加する

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -7,6 +7,7 @@
 {
   imports = [
     ./modules/packages.nix
+    ./modules/fonts.nix
     ./modules/git.nix
     ./modules/gpg.nix
     ./modules/ssh.nix

--- a/modules/fonts.nix
+++ b/modules/fonts.nix
@@ -1,0 +1,24 @@
+{ pkgs, ... }:
+{
+  home.packages = with pkgs; [
+    noto-fonts
+    noto-fonts-cjk-sans
+    noto-fonts-cjk-serif
+    noto-fonts-color-emoji
+  ];
+
+  fonts.fontconfig = {
+    enable = true;
+    defaultFonts = {
+      sansSerif = [
+        "Noto Sans CJK JP"
+        "Noto Sans"
+      ];
+      serif = [
+        "Noto Serif CJK JP"
+        "Noto Serif"
+      ];
+      emoji = [ "Noto Color Emoji" ];
+    };
+  };
+}


### PR DESCRIPTION
## 概要
- WSL 側で GUI アプリが日本語を描画できず文字化けする状況に対して、Home Manager で Noto 系フォントを配備するようにしました。
- 新しく `modules/fonts.nix` を追加し、`noto-fonts`、CJK Sans/Serif、Color Emoji と `fonts.fontconfig.enable` をまとめて管理するようにしました。
- `sans-serif`、`serif`、`emoji` の既定フォントを Noto 系に寄せ、Linux 側 fontconfig を参照するアプリで日本語フォールバックしやすくしました。

## 確認事項
- `nixfmt home.nix modules/fonts.nix` を実行し、対象ファイルの整形が通ることを確認しました。
- `home-manager build --flake .#testuser` を実行し、追加したフォント module を含めて Home Manager の評価と生成が成功することを確認しました。
- 実機の WSL GUI アプリ表示まではこの場では未確認です。反映後の見た目は `home-manager switch --flake .#rito528` 適用後に確認が必要です。

🤖 Generated with Codex