### PR TITLE
fix: nodePackages 廃止に伴い typescript-language-server の参照を修正する

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -133,7 +133,7 @@
             pkgs.nodejs_22
             pkgs.pnpm
             pkgs.typescript
-            pkgs.nodePackages.typescript-language-server
+            pkgs.typescript-language-server
             pkgs.vscode-langservers-extracted
           ];
         };

--- a/templates/typescript/flake.nix
+++ b/templates/typescript/flake.nix
@@ -15,7 +15,7 @@
           pkgs.nodejs_24
           pkgs.pnpm
           pkgs.typescript
-          pkgs.nodePackages.typescript-language-server
+          pkgs.typescript-language-server
           pkgs.vscode-langservers-extracted
         ];
       };


### PR DESCRIPTION
## 概要

- nixpkgs で `nodePackages` 名前空間が廃止されたため、TypeScript devshell が起動できなくなっていた
- `pkgs.nodePackages.typescript-language-server` を `pkgs.typescript-language-server` に変更
- `flake.nix` と `templates/typescript/flake.nix` の両方を修正

## 確認事項

- ローカルで direnv による TypeScript devshell 起動時にエラーが発生していたことを確認済み
- 修正後の参照先 `pkgs.typescript-language-server` は nixpkgs に存在することを確認
- CI (`nix flake check`) は devShells を網羅的にビルド検証していないため、今回のような `nodePackages` 廃止は PR マージ前に検知できていなかった点が残課題

## 補足

- CI で devShells を明示的にビルドするステップを追加することで将来同様の問題を防げる。別途対応予定。

🤖 Generated with Claude Code