### PR TITLE
fix: Neovim LSP の executable チェックを除去する

### DIFF
--- a/config/nvim/lua/plugins/lsp.lua
+++ b/config/nvim/lua/plugins/lsp.lua
@@ -3,26 +3,20 @@ return {
     "neovim/nvim-lspconfig",
     event = { "BufReadPre", "BufNewFile" },
     config = function()
-      if vim.fn.executable("typescript-language-server") == 1 then
-        vim.lsp.config("ts_ls", {})
-        vim.lsp.enable("ts_ls")
-      end
+      vim.lsp.config("ts_ls", {})
+      vim.lsp.enable("ts_ls")
 
-      if vim.fn.executable("vscode-eslint-language-server") == 1 then
-        vim.lsp.config("eslint", {
-          settings = {
-            eslint = {
-              autoFixOnSave = true,
-            },
+      vim.lsp.config("eslint", {
+        settings = {
+          eslint = {
+            autoFixOnSave = true,
           },
-        })
-        vim.lsp.enable("eslint")
-      end
+        },
+      })
+      vim.lsp.enable("eslint")
 
-      if vim.fn.executable("vscode-json-language-server") == 1 then
-        vim.lsp.config("jsonls", {})
-        vim.lsp.enable("jsonls")
-      end
+      vim.lsp.config("jsonls", {})
+      vim.lsp.enable("jsonls")
     end,
   },
 }


### PR DESCRIPTION
## 概要

- devshell の PATH が nvim 起動時に反映されていない場合、`executable()` チェックが失敗して LSP が有効化されない問題があった
- `ts_ls`・`eslint`・`jsonls` の全サーバーから `executable()` ガードを除去し、常に有効化するよう変更
- サーバーのバイナリが PATH にない場合は Neovim が起動を試みないだけで無害

## 確認事項

- devshell 外で nvim を起動した場合、LSP サーバーが PATH にないため実際には接続しないことを設計上の前提として確認済み
- 実際に devshell 内で LSP が動作するかはユーザー側での動作確認待ち

🤖 Generated with Claude Code