### PR TITLE
feat: direnv 用 .envrc を生成する nix-init-env スクリプトを追加する

### DIFF
--- a/modules/scripts/default.nix
+++ b/modules/scripts/default.nix
@@ -1,4 +1,7 @@
 { ... }:
 {
-  imports = [ ./switch-branch-with-refresh.nix ];
+  imports = [
+    ./switch-branch-with-refresh.nix
+    ./nix-init-env.nix
+  ];
 }

--- a/modules/scripts/nix-init-env.nix
+++ b/modules/scripts/nix-init-env.nix
@@ -1,0 +1,14 @@
+{ pkgs, ... }:
+{
+  home.packages = [
+    (pkgs.writeShellApplication {
+      name = "nix-init-env";
+      runtimeInputs = [
+        pkgs.nix
+        pkgs.jq
+        pkgs.coreutils
+      ];
+      text = builtins.readFile ./nix-init-env.sh;
+    })
+  ];
+}

--- a/modules/scripts/nix-init-env.sh
+++ b/modules/scripts/nix-init-env.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+REPO="github:rito528/dotfiles"
+
+echo "Fetching templates from $REPO ..."
+mapfile -t TEMPLATES < <(nix flake show "$REPO" --json 2>/dev/null | jq -r '.templates | keys[]' | sort)
+
+if [ ${#TEMPLATES[@]} -eq 0 ]; then
+  echo "No templates found." >&2
+  exit 1
+fi
+
+# "local" を末尾に追加
+TEMPLATES+=("local")
+
+build_description() {
+  local name="$1"
+  if [ "$name" = "local" ]; then
+    printf "local flake            (use flake)"
+  else
+    printf "%-30s (%s#%s)" "$name" "$REPO" "$name"
+  fi
+}
+
+# テンプレートを選択する
+if command -v fzf > /dev/null 2>&1; then
+  DESCRIPTIONS=()
+  for t in "${TEMPLATES[@]}"; do
+    DESCRIPTIONS+=("$(build_description "$t")")
+  done
+  selected=$(printf '%s\n' "${DESCRIPTIONS[@]}" | fzf --prompt="Select template: " --height=15 --reverse)
+  [ -z "$selected" ] && { echo "Aborted."; exit 0; }
+  for i in "${!DESCRIPTIONS[@]}"; do
+    if [ "${DESCRIPTIONS[$i]}" = "$selected" ]; then
+      template="${TEMPLATES[$i]}"
+      break
+    fi
+  done
+else
+  echo "Select template:"
+  for i in "${!TEMPLATES[@]}"; do
+    echo "  $((i + 1))) $(build_description "${TEMPLATES[$i]}")"
+  done
+  printf "> "
+  read -r choice
+  if ! [[ "$choice" =~ ^[0-9]+$ ]] || [ "$choice" -lt 1 ] || [ "$choice" -gt ${#TEMPLATES[@]} ]; then
+    echo "Invalid selection." >&2
+    exit 1
+  fi
+  template="${TEMPLATES[$((choice - 1))]}"
+fi
+
+if [ "$template" = "local" ]; then
+  envrc_content="use flake"
+else
+  envrc_content="use flake '$REPO#$template'"
+fi
+
+# .envrc が既に存在する場合は確認
+if [ -f .envrc ]; then
+  echo ".envrc already exists:"
+  echo "  $(cat .envrc)"
+  printf "Overwrite? [y/N] "
+  read -r overwrite
+  if [ "$overwrite" != "y" ] && [ "$overwrite" != "Y" ]; then
+    echo "Aborted."
+    exit 0
+  fi
+fi
+
+echo "$envrc_content" > .envrc
+echo "Created .envrc: $envrc_content"
+
+if command -v direnv > /dev/null 2>&1; then
+  printf "Run 'direnv allow'? [Y/n] "
+  read -r allow
+  if [ "$allow" != "n" ] && [ "$allow" != "N" ]; then
+    direnv allow
+  fi
+fi


### PR DESCRIPTION
flake から利用可能なテンプレート一覧を動的に取得し、選択した
テンプレートに対応する .envrc を生成する nix-init-env コマンドを追加する。
fzf が利用可能な場合はインタラクティブ選択、ない場合は番号入力で選択できる。
シェルスクリプトは builtins.readFile で別ファイルとして管理し、
Nix 定義とシェルロジックを分離している。