### PR TITLE
fix: nix-init-env でリモート flake の lock file 書き込みエラーを修正し README に追記する

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,3 +162,19 @@ direnv allow
 ```
 
 > `.envrc` はプロジェクト固有の設定のため、global gitignore に追加することを推奨します。
+
+### nix-init-env コマンド
+
+`nix-init-env` は、プロジェクトディレクトリに `.envrc` を対話的に生成するコマンドです。
+このリポジトリで管理されているテンプレート一覧を取得し、選択した内容で `.envrc` を作成します。
+
+```bash
+# プロジェクトディレクトリで実行
+nix-init-env
+```
+
+- fzf がインストールされている場合はインタラクティブに選択できます
+- `local` を選択すると `use flake`（ローカル flake 参照）が生成されます
+- それ以外を選択すると `use flake 'github:rito528/dotfiles#<template>'` が生成されます
+- `.envrc` が既に存在する場合は上書き確認を行います
+- 生成後、`direnv allow` を実行するか確認します

--- a/modules/scripts/nix-init-env.sh
+++ b/modules/scripts/nix-init-env.sh
@@ -3,7 +3,7 @@
 REPO="github:rito528/dotfiles"
 
 echo "Fetching templates from $REPO ..."
-mapfile -t TEMPLATES < <(nix flake show "$REPO" --json 2>/dev/null | jq -r '.templates | keys[]' | sort)
+mapfile -t TEMPLATES < <(nix flake show "$REPO" --json --no-write-lock-file 2>/dev/null | jq -r '.templates | keys[]' | sort)
 
 if [ ${#TEMPLATES[@]} -eq 0 ]; then
   echo "No templates found." >&2


### PR DESCRIPTION
## 概要

- `nix flake show` がリモート flake の lock file 更新を試みてエラーになっていた問題を修正
- `--no-write-lock-file` オプションを追加し、テンプレート一覧を正常に取得できるようにした
- README の「direnv との連携」セクションに `nix-init-env` コマンドの説明を追加した

## 確認事項

- `nix flake show github:rito528/dotfiles --json --no-write-lock-file` でエラーが解消されることを手動で確認済み
- README の記載内容はスクリプトの実際の挙動（fzf 有無の分岐、local 選択時の挙動、既存 `.envrc` の上書き確認）と一致している

🤖 Generated with Claude Code