### PR TITLE
fix: nix-init-env でテンプレートを dir パラメータで直接参照する

### DIFF
--- a/modules/scripts/nix-init-env.sh
+++ b/modules/scripts/nix-init-env.sh
@@ -18,7 +18,7 @@ build_description() {
   if [ "$name" = "local" ]; then
     printf "local flake            (use flake)"
   else
-    printf "%-30s (%s#%s)" "$name" "$REPO" "$name"
+    printf "%-30s (%s?dir=templates/%s)" "$name" "$REPO" "$name"
   fi
 }
 
@@ -53,7 +53,7 @@ fi
 if [ "$template" = "local" ]; then
   envrc_content="use flake"
 else
-  envrc_content="use flake '$REPO#$template'"
+  envrc_content="use flake '${REPO}?dir=templates/${template}' --no-write-lock-file"
 fi
 
 # .envrc が既に存在する場合は確認


### PR DESCRIPTION
## 概要
- テンプレート選択時に `github:rito528/dotfiles#<name>` 形式で参照していたが、このフレークには `devShells` がなく direnv がエラーになっていた
- `github:rito528/dotfiles?dir=templates/<name>` 形式に変更し、テンプレートの `flake.nix` を直接参照するよう修正
- リモートフレークの lock file 書き込みエラーを回避するため `--no-write-lock-file` を付与

## 確認事項
- 実際に `nix-init-env` を実行し、テンプレート選択後に `.envrc` が正しい形式で生成されること、`direnv allow` で devShell が起動することをユーザーが確認済み

## 補足
- `local` 選択時の動作（`use flake` のみ）は変更なし

🤖 Generated with Claude Code