### PR TITLE
fix: Actions PR 作成後の force push による minimumReleaseAge リセットを防ぐ

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,7 @@
       "minimumReleaseAge": "6 days",
       "internalChecksFilter": "strict",
       "prCreation": "not-pending",
+      "rebaseWhen": "never",
       "schedule": [
         "* * * * 0"
       ]


### PR DESCRIPTION
## 概要
- GitHub Actions の Renovate 更新で、PR 作成後に新しいバージョンが出ると force push され、`minimumReleaseAge` がリセットされていつまでもマージできない問題があった
- `rebaseWhen: "never"` を追加し、一度作成した PR を Renovate が更新しないようにした
- 新しいバージョンが出た場合は、翌週のスケジュール実行で改めて PR が作成される運用になる

## 確認事項
- 設定値の追加のみで、Renovate の動作はサービス側が制御するため手元での検証は不可
- [Renovate ドキュメント](https://docs.renovatebot.com/configuration-options/#rebasewhen) で `rebaseWhen: "never"` が既存 PR を更新しないオプションであることを確認済み

🤖 Generated with Claude Code