### PR TITLE
fix: seichi-portal-backend テンプレートで rust-analyzer が標準ライブラリを読めない問題を修正する

### DIFF
--- a/templates/seichi-portal-backend/flake.nix
+++ b/templates/seichi-portal-backend/flake.nix
@@ -21,7 +21,12 @@
     {
       devShells.${system}.default = pkgs.mkShell {
         buildInputs = [
-          pkgs.rust-bin.stable.latest.default
+          (pkgs.rust-bin.stable.latest.default.override {
+            extensions = [
+              "rust-src"
+              "rust-analyzer"
+            ];
+          })
           pkgs.pkg-config
           pkgs.openssl
           pkgs.cargo-make


### PR DESCRIPTION
## 概要

- `templates/seichi-portal-backend/flake.nix` の Rust ツールチェインに `rust-src` と `rust-analyzer` コンポーネントを追加
- `rust-bin.stable.latest.default` はデフォルトで `rust-src` を含まないため、rust-analyzer が sysroot から標準ライブラリのソースを見つけられず `can't load standard library` エラーが発生していた
- `extensions` で明示的に指定することで解消する

## 確認事項

- VSCode のログで `can't load standard library` および `Failed to read Cargo metadata` エラーが出ていることを確認済み
- 原因は `rust-src` コンポーネント不足であり、`extensions` に追加することで解消される想定
- `nix develop` でシェルを再起動後、VSCode を開き直して動作確認が必要

## 補足

- `rust-analyzer` も `extensions` 経由で追加することで、nixpkgs の別パッケージではなく toolchain と同じバージョンの rust-analyzer が使われるようになる

🤖 Generated with Claude Code