### PR TITLE
fix: oil で設定ファイルを表示する

### DIFF
--- a/config/nvim/lua/plugins/navigation.lua
+++ b/config/nvim/lua/plugins/navigation.lua
@@ -8,7 +8,11 @@ return {
     keys = {
       { "-", "<Cmd>Oil<CR>", desc = "Open parent directory" },
     },
-    opts = {},
+    opts = {
+      view_options = {
+        show_hidden = true,
+      },
+    },
   },
   {
     "nvim-telescope/telescope.nvim",


### PR DESCRIPTION
## 概要
- Neovim の `oil.nvim` で dotfile が一覧に出ず、設定ファイルへ移動しづらい状態を解消
- `config/nvim/lua/plugins/navigation.lua` に `view_options.show_hidden = true` を追加し、隠しファイルを表示するよう変更
- 影響範囲は `oil.nvim` のファイル一覧表示のみ

## 確認事項
- `main...HEAD` の差分を確認し、`oil.nvim` の表示設定だけが変更されていることを確認
- 追加の実機確認は未実施。Lua テーブルの単純な設定追加で、影響範囲が限定的なため PR 化

🤖 Generated with Codex