### PR TITLE
fix: Rust の Treesitter ハイライトを補強する

### DIFF
--- a/config/nvim/after/queries/rust/highlights.scm
+++ b/config/nvim/after/queries/rust/highlights.scm
@@ -1,0 +1,13 @@
+; Make derive targets stand out instead of falling back to plain identifiers.
+(attribute
+  (identifier) @_attribute_name
+  arguments: (token_tree
+    [
+      (identifier) @type
+      (type_identifier) @type
+      (scoped_identifier
+        name: (identifier) @type)
+      (scoped_type_identifier
+        name: (type_identifier) @type)
+    ])
+  (#eq? @_attribute_name "derive"))

--- a/config/nvim/lua/plugins/editor.lua
+++ b/config/nvim/lua/plugins/editor.lua
@@ -5,6 +5,22 @@ return {
     opts = {
       style = "night",
       transparent = false,
+      on_highlights = function(highlights, colors)
+        highlights["@attribute"] = { fg = colors.orange, italic = true }
+        highlights["@function.macro"] = { fg = colors.orange, bold = true }
+        highlights["@module"] = { fg = colors.cyan }
+        highlights["@constructor"] = { fg = colors.magenta, bold = true }
+        highlights["@type"] = { fg = colors.blue, bold = true }
+        highlights["@type.builtin"] = { fg = colors.teal, italic = true }
+        highlights["@variable.member"] = { fg = colors.cyan }
+
+        highlights["@lsp.type.deriveHelper"] = { fg = colors.orange, italic = true, bold = true }
+        highlights["@lsp.type.decorator"] = { fg = colors.orange, italic = true }
+        highlights["@lsp.type.lifetime"] = { fg = colors.red, italic = true }
+        highlights["@lsp.type.namespace"] = { fg = colors.cyan }
+        highlights["@lsp.type.selfKeyword"] = { fg = colors.red, italic = true }
+        highlights["@lsp.type.selfTypeKeyword"] = { fg = colors.red, italic = true }
+      end,
     },
   },
   {

--- a/config/nvim/lua/plugins/treesitter.lua
+++ b/config/nvim/lua/plugins/treesitter.lua
@@ -19,7 +19,10 @@ return {
           "yaml",
           "sql",
         },
-        highlight = { enable = true },
+        auto_install = true,
+        highlight = {
+          enable = true,
+        },
         indent = { enable = true },
       })
     end,


### PR DESCRIPTION
## 概要
- Rust ファイルで Treesitter parser が未導入でも設定が有効に見えてしまい、ハイライトが従来の syntax に寄って弱く見える状態を改善しました。
- nvim-treesitter の `auto_install` を有効にし、Rust の `derive` 向け追加クエリを入れて属性内の型名を plain text に見せにくくしました。
- tokyonight の Treesitter/LSP キャプチャを調整し、attribute、macro、type、lifetime など Rust で見分けたい要素の視認性を上げました。

## 確認事項
- `nvim --headless` で起動し、設定変更による起動エラーが出ないことを確認しました。
- ローカル確認では Rust Treesitter parser 自体が未導入だったため、今回の修正で自動導入経路を追加しています。初回は `auto_install` または `:TSInstall rust` により parser が入る前提です。
- 実際の Rust バッファ表示はこの環境では目視確認していないため、レビュー時は `#[derive(...)]`、macro、型名の見え方を重点的に見てもらえると助かります。

## 補足
- 根本原因はテーマ色だけではなく、Rust parser が入っていなかったことでした。

🤖 Generated with Codex