### PR TITLE
ci: integration test に nvim ヘッドレス起動テストを追加する

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -37,3 +37,9 @@ jobs:
           CI: true
         run: |
           nix run nixpkgs#home-manager -- build --flake .#testuser
+
+      - name: Test neovim headless startup
+        run: |
+          nixvim=$(nix-store -q --references "$(readlink result/home-path)" | grep nixvim)
+          XDG_CONFIG_HOME="$(readlink -f result/home-files/.config)" \
+            "$nixvim/bin/nvim" --headless -c "quitall"

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -41,5 +41,9 @@ jobs:
       - name: Test neovim headless startup
         run: |
           nixvim=$(nix-store -q --references "$(readlink result/home-path)" | grep nixvim)
+          cache_dir=$(mktemp -d)
+          mkdir -p "$cache_dir/nvim"
           XDG_CONFIG_HOME="$(readlink -f result/home-files/.config)" \
+            XDG_CACHE_HOME="$cache_dir" \
+            XDG_DATA_HOME="$(mktemp -d)" \
             "$nixvim/bin/nvim" --headless -c "quitall"


### PR DESCRIPTION
## 概要

- `home-manager build` は Nix としてビルドが通るかしか保証しておらず、nvim 実起動時のプラグインロードエラーや Lua 初期化エラーを検出できなかった
- nixvim ラッパーバイナリ（`packpath` にプラグインが含まれる）を `result/home-path` の Nix 依存グラフから取得し、ビルドした設定でヘッドレス起動することで起動時エラーを PR 段階で検出できるようにした
- 追加の `nix build` 呼び出しは不要で、`nix-store -q --references` のみで nixvim パスを取得できる

## 確認事項

- ローカルで `home-manager build` 後に同コマンドを実行し、exit 0 かつ stderr 出力なしを確認した
- `result/home-path/bin/nvim` は素の neovim シンボリックリンク（plugin なし）で使えないことを確認し、nixvim ラッパーを使う方針に変更した

## 補足

- nvim の起動テストなので CI 上の実行時間への影響はほぼない
- LSP バイナリ（`package = null` で system 依存）の起動確認は CI 環境に存在しないため対象外としている

🤖 Generated with Claude Code