### PR TITLE
feat(nvim): LSP diagnostic のエラー内容をインライン表示する

### DIFF
--- a/modules/neovim/lsp.nix
+++ b/modules/neovim/lsp.nix
@@ -1,5 +1,14 @@
 { ... }:
 {
+  extraConfigLua = ''
+    vim.diagnostic.config({
+      virtual_text = {
+        prefix = "●",
+        source = "if_many",
+      },
+    })
+  '';
+
   plugins = {
     "copilot-vim" = {
       enable = true;


### PR DESCRIPTION
## 概要
- エラーの存在（E マーカーと赤線）は表示されていたが、エラーの内容がわからない問題を解消する
- `vim.diagnostic.config()` で `virtual_text` を有効化し、エラーメッセージをコード右側にインライン表示する
- `prefix = "●"` でマーカーを見やすくし、`source = "if_many"` で複数ソース混在時のみソース名を表示する

## 確認事項
- `home-manager build --flake .#testuser` が成功することを確認した

🤖 Generated with Claude Code