### PR TITLE
feat(nvim): Visual モードでインデント後も選択を維持する

### DIFF
--- a/modules/neovim/base.nix
+++ b/modules/neovim/base.nix
@@ -45,6 +45,18 @@
       options.desc = "Toggle comment";
     }
     {
+      key = ">";
+      mode = "v";
+      action = ">gv";
+      options.desc = "Indent and keep selection";
+    }
+    {
+      key = "<";
+      mode = "v";
+      action = "<gv";
+      options.desc = "Unindent and keep selection";
+    }
+    {
       key = "-";
       mode = "n";
       action = "<Cmd>Oil<CR>";


### PR DESCRIPTION
## 概要
- `>` / `<` でインデントするたびに Visual モードの選択が解除される問題を解消する
- `>gv` / `<gv` にリマップし、インデント操作後も選択状態を維持するようにする

## 確認事項
- `home-manager build --flake .#testuser` が成功することを確認した
- キーマップは nixvim の `keymaps` に追加しており、既存のコメントトグル（`<C-/>` など）と競合しない

🤖 Generated with Claude Code