### PR TITLE
ci(nvim): キーマップ重複を CI で自動検出する

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -8,6 +8,7 @@ on:
       - 'flake.lock'
       - 'config/**'
       - 'install/**'
+      - 'modules/neovim/check-keymaps.lua'
       - '.github/workflows/integration-test.yaml'
   pull_request:
     branches: [main]
@@ -16,6 +17,7 @@ on:
       - 'flake.lock'
       - 'config/**'
       - 'install/**'
+      - 'modules/neovim/check-keymaps.lua'
       - '.github/workflows/integration-test.yaml'
 
 jobs:
@@ -47,3 +49,14 @@ jobs:
             XDG_CACHE_HOME="$cache_dir" \
             XDG_DATA_HOME="$(mktemp -d)" \
             "$nixvim/bin/nvim" --headless -c "quitall"
+
+      - name: Check duplicate keymaps
+        run: |
+          nixvim=$(nix-store -q --references "$(readlink result/home-path)" | grep nixvim)
+          cache_dir=$(mktemp -d)
+          mkdir -p "$cache_dir/nvim"
+          XDG_CONFIG_HOME="$(readlink -f result/home-files/.config)" \
+            XDG_CACHE_HOME="$cache_dir" \
+            XDG_DATA_HOME="$(mktemp -d)" \
+            "$nixvim/bin/nvim" --headless \
+              -S modules/neovim/check-keymaps.lua

--- a/modules/neovim/check-keymaps.lua
+++ b/modules/neovim/check-keymaps.lua
@@ -20,7 +20,8 @@ local function find_duplicates(mode)
 end
 
 local duplicates = vim.iter({ "n", "v", "x", "i", "o", "s", "c", "t" })
-  :flatmap(find_duplicates)
+  :map(find_duplicates)
+  :flatten()
   :totable()
 
 for _, d in ipairs(duplicates) do

--- a/modules/neovim/check-keymaps.lua
+++ b/modules/neovim/check-keymaps.lua
@@ -1,0 +1,40 @@
+local function label(m)
+  return m.desc or m.rhs or "<lua>"
+end
+
+local function group_by_lhs(maps)
+  return vim.iter(maps)
+    :filter(function(m) return not m.lhs:match("^<Plug>") end)
+    :fold({}, function(acc, m)
+      acc[m.lhs] = acc[m.lhs] or {}
+      table.insert(acc[m.lhs], m)
+      return acc
+    end)
+end
+
+local function find_duplicates(mode)
+  return vim.iter(group_by_lhs(vim.api.nvim_get_keymap(mode)))
+    :filter(function(_, ms) return #ms > 1 end)
+    :map(function(lhs, ms) return { mode = mode, lhs = lhs, maps = ms } end)
+    :totable()
+end
+
+local duplicates = vim.iter({ "n", "v", "x", "i", "o", "s", "c", "t" })
+  :flatmap(find_duplicates)
+  :totable()
+
+for _, d in ipairs(duplicates) do
+  io.stderr:write(string.format(
+    "[DUPLICATE] mode=%s  key=%s\n  (1) %s\n  (2) %s\n",
+    d.mode,
+    d.lhs,
+    label(d.maps[1]),
+    label(d.maps[2])
+  ))
+end
+
+if #duplicates > 0 then
+  vim.cmd("cquit 1")
+else
+  vim.cmd("quitall")
+end


### PR DESCRIPTION
## 概要

- Neovim のキーバインドが増えるにつれ重複や無効な割り当てが混入しやすいため、CI で自動検出する仕組みを導入した
- `modules/neovim/check-keymaps.lua` を新規追加。`vim.iter` を用いた関数型スタイルで全モードのグローバルキーマップを取得し、lhs の重複を検出する
- `integration-test.yaml` に `Check duplicate keymaps` ステップを追加。home-manager ビルド後の成果物に対して上記スクリプトを実行する

## 確認事項

- home-manager build での動作は CI で確認予定
- ローカル環境での `nvim --headless -S modules/neovim/check-keymaps.lua` 実行は、nixvim バイナリが CI ビルド成果物経由で参照されるため未実施

## 補足

- LSP の `on_attach` で登録されるバッファローカルマップは headless 起動では LSP が attach されないため検出対象外（既知の制約）
- pre-commit hook での検出も検討したが、Nix 管理の設定では `home-manager switch` 後でないとデプロイ済み設定が更新されず、コミット前の staged な変更を正しく検査できないため CI のみとした

🤖 Generated with Claude Code