### PR TITLE
docs: README のツリー構造を prose に置き換え、neovim サブドキュメントを追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,4 +70,5 @@
 - `config/` 配下の詳細な編集ルールは `config/AGENTS.md` を参照してください
 - Claude 関連の詳細は `config/claude/AGENTS.md`, `config/claude/README.md` を参照してください
 - agents 配下の詳細は `config/agents/AGENTS.md`, `config/agents/skills/README.md` を参照してください
+- Neovim 設定の詳細は `modules/neovim/AGENTS.md` を参照してください
 - 実装の全体像や詳細一覧が必要な場合は、まずコードと生成物を確認してください

--- a/README.md
+++ b/README.md
@@ -10,56 +10,16 @@
 - **シークレット管理**: [Doppler](https://www.doppler.com/) (GPG/SSH キーも含む)
 - **シェル**: zsh
 
-## ディレクトリ構成
+## リポジトリ構成
 
-```
-dotfiles/
-├── .github/workflows/        # GitHub Actions CI 定義
-│   ├── lint.yaml             # shellcheck・nixfmt Lint
-│   ├── integration-test.yaml # Cachix を使った home-manager ビルド検証
-│   ├── nix.yaml              # Nix flake check
-│   ├── devshell.yaml         # templates/ 配下の devShell ビルド検証
-│   ├── nix-update-pr.yaml    # Renovate 時のハッシュ自動更新
-│   ├── update-flake-lock.yaml # 週次 flake.lock 更新
-│   ├── e2e-setup-test.yaml   # セットアップ E2E テスト
-│   └── renovate.yaml         # Renovate 設定
-├── .agents/                  # エージェント横断のローカル AI 定義
-│   └── skills/               # Codex / Claude / Copilot 共有スキル
-├── .claude/                  # Claude Code ローカル設定
-│   ├── agents/               # Claude 用カスタムエージェント
-│   └── skills -> ../.agents/skills # 共有スキルへの互換リンク
-├── config/                   # home-manager が配置する設定ファイル群
-│   ├── agents/
-│   │   └── skills/           # home-manager 配備用 AI スキル定義
-│   ├── AGENTS.md             # config/ 配下専用の運用ルール
-│   ├── claude/               # Claude Code 設定
-│   │   ├── hooks/notify.sh   # WSL 向け Windows Toast 通知
-│   │   ├── settings.json     # フック・プラグイン設定
-│   └── README.md             # config/ 全体の説明
-├── .githooks/                # このリポジトリ専用の Git hooks
-├── flake.nix                 # フレーク定義
-├── flake.lock                # フレークロックファイル
-├── home.nix                  # パッケージ・ファイル配置の宣言
-├── modules/                  # 機能別 Nix モジュール
-│   ├── packages.nix          # コアパッケージ
-│   ├── git.nix               # Git 設定・GPG 署名
-│   ├── gpg.nix               # GPG/SSH キー管理 (Doppler)
-│   ├── shell.nix             # zsh・starship・direnv
-│   ├── ssh.nix               # SSH 設定
-│   ├── codex.nix             # Codex CLI 設定配置
-│   ├── claude.nix            # Claude Code 設定配置
-│   ├── gitleaks.nix          # gitleaks
-│   ├── npm/                  # npm/pnpm パッケージ管理
-│   │   ├── default.nix
-│   │   └── packages/         # パッケージ定義 (例: difit.nix)
-│   ├── packages/             # カスタムパッケージ (actrun, git-wt など)
-│   └── scripts/              # カスタムスクリプト
-├── templates/                # Nix 開発環境テンプレート
-├── install/                  # セットアップスクリプト
-│   ├── common/               # OS 共通スクリプト (nix.sh, home-manager.sh, chsh-zsh.sh, setup-local-hooks.sh)
-│   └── ubuntu/               # Ubuntu / Debian 系固有スクリプト
-└── setup.sh                  # セットアップエントリポイント
-```
+- **`home.nix` / `modules/`**: Home Manager の設定と配備定義の正本。機能ごとに Nix モジュールを分割して管理しています。
+- **`config/`**: home-manager が `~` 以下に配置する設定ファイルの正本。Claude Code 設定・AI スキル定義などを含みます。詳細は `config/AGENTS.md` と `config/README.md` を参照してください。
+- **`.agents/skills/`**: リポジトリローカルの共有 AI スキル定義（Codex / Claude / Copilot などが参照）。
+- **`.claude/`**: Claude Code ローカル設定。`skills` は `.agents/skills/` へのシンボリックリンクです。
+- **`.githooks/`**: このリポジトリ専用の Git hooks の正本。
+- **`install/`**: セットアップスクリプト群。`setup.sh` がエントリポイントです。
+- **`templates/`**: プロジェクトごとの Nix 開発環境テンプレート。
+- **`.github/workflows/`**: CI 定義。lint・ビルド検証・E2E テストなどを含みます。
 
 ## セットアップ手順
 

--- a/modules/neovim/AGENTS.md
+++ b/modules/neovim/AGENTS.md
@@ -1,0 +1,22 @@
+# modules/neovim/
+
+Neovim の設定は [nixvim](https://github.com/nix-community/home-manager) を通じて宣言的に管理しています。
+`default.nix` が各設定ファイルをインポートする入口です。
+
+## ファイルの責務
+
+設定は関心ごとにファイルを分けています。基本設定、プラグイン、LSP、言語固有設定（Scala）という分割になっています。
+
+## check-keymaps.lua について
+
+`check-keymaps.lua` は **Neovim の起動時には読み込まれません**。CI でのみ使用するヘッドレス実行スクリプトです。
+
+- 役割: 全モードのキーマップを走査し、重複を検出して終了コードで報告する
+- 実行タイミング: `integration-test.yaml` の「Check duplicate keymaps」ステップ
+- 修正方法: 重複が検出された場合、キーマップを定義している `.nix` ファイルを確認して競合を解消する
+
+新しいキーマップを追加した場合、CI がこのスクリプトで重複を検出します。ローカルで確認したい場合は integration-test.yaml の該当ステップを参考に同じコマンドを実行してください。
+
+## Treesitter ランタイム
+
+`default.nix` では `NVIM_TREESITTER_RUNTIME_GLOBAL` 環境変数を通じて共通の Treesitter パーサーランタイムを設定しています。テンプレートや外部設定ファイルとの共有に関する判断については、プロジェクトルートの AGENTS.md を参照してください。

--- a/modules/neovim/CLAUDE.md
+++ b/modules/neovim/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## 概要

- README.md の「ディレクトリ構成」セクションのツリー表記を削除し、各ディレクトリの役割を prose で説明する形式に変更した
- ファイルを追加・削除するたびに手動更新が必要なツリーは実態と乖離しやすいため、腐らない形式を採用した
- `modules/neovim/` に `AGENTS.md` と `CLAUDE.md`（`AGENTS.md` へのシンボリックリンク）を新規追加した
- ルートの `AGENTS.md` の「7. ディレクトリ別の参照先」に `modules/neovim/AGENTS.md` への参照を追加した

## 確認事項

- ドキュメント変更のみのため home-manager ビルドへの影響なし
- シンボリックリンク `modules/neovim/CLAUDE.md -> AGENTS.md` が正しく作成されていることを `git status` で確認した

🤖 Generated with Claude Code