### PR TITLE
fix(nvim): conceal で記号が隠れないようにする

### DIFF
--- a/modules/neovim/base.nix
+++ b/modules/neovim/base.nix
@@ -9,7 +9,7 @@
   };
 
   opts = {
-    conceallevel = 2;
+    conceallevel = 0;
     cursorline = true;
     number = true;
     numberwidth = 4;


### PR DESCRIPTION
## 概要
- Neovim のグローバル設定 `conceallevel` を `2` から `0` に変更し、Markdown の `**` や引用符などの記号がカーソル行以外で隠れないようにしました。
- `vim-markdown` 側では個別 conceal を無効化済みでしたが、全体設定が残っていたため、ファイル種別を問わず発生していた表示差を解消しています。

## 確認事項
- `nixfmt modules/neovim/base.nix` を実行し、対象の Nix ファイルを整形しました。
- `home-manager build --flake .#testuser` を実行し、この設定変更を含む Home Manager の評価とビルドが成功することを確認しました。

🤖 Generated with Codex