### PR TITLE
fix: Renovate の action スケジュール式を later.js 形式に修正

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,7 +22,7 @@
       "prCreation": "not-pending",
       "rebaseWhen": "never",
       "schedule": [
-        "* * * * 0"
+        "on sunday"
       ]
     }
   ],


### PR DESCRIPTION
## 概要

- `packageRules` の action タイプ向けスケジュールを `"* * * * 0"` から `"on sunday"` に変更
- cron 形式の `"* * * * 0"` は Renovate のスケジュールパーサー（later.js ベース）で正しく解釈されない場合があり、日曜日になっても "Awaiting Schedule" のまま PR が作成されない問題があった
- Renovate が推奨するテキスト形式を使うことで、スケジュールが確実に評価されるようにする

## 確認事項

- non-action パッケージの PR 作成は正常に動作しており、今回の変更対象外であることを確認済み
- 次の日曜日に Renovate が動いたとき、action タイプの PR が作成されるかで効果を確認予定

🤖 Generated with Claude Code