### PR TITLE
fix: barbar.nvim の unfree ライセンスを allowUnfreePredicate に追加

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,7 @@
             "claude-code"
             "copilot.vim"
             "copilot-cli"
+            "vimplugin-barbar.nvim"
           ];
       };
       mkHomeConfig =


### PR DESCRIPTION
## 概要

- nixpkgs が `barbar.nvim` を unfree ライセンスとしてマークしており、CI の home-manager build が失敗していた
- `flake.nix` の `allowUnfreePredicate` に `vimplugin-barbar.nvim` を追加して解消

## 確認事項

- ローカルで `nix run nixpkgs#home-manager -- build --flake .#testuser` を実行し、ビルドが成功することを確認済み

🤖 Generated with Claude Code