### PR TITLE
fix: allowUnfreePredicate の barbar.nvim パッケージ名を修正

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
             "claude-code"
             "copilot.vim"
             "copilot-cli"
-            "vimplugin-barbar.nvim"
+            "barbar.nvim"
           ];
       };
       mkHomeConfig =


### PR DESCRIPTION
## 概要

- #347 で `vimplugin-barbar.nvim` と指定していたが、正しいパッケージ名は `barbar.nvim`
- nixpkgs のエラーメッセージのサンプルに `"barbar.nvim"` と明示されていた

## 確認事項

- ローカルで `nix run nixpkgs#home-manager -- build --flake .#testuser` を実行し、ビルドが成功することを確認済み

🤖 Generated with Claude Code