### PR TITLE
feat(nvim): <leader>gs で Telescope git_status を開けるようにする

### DIFF
--- a/modules/neovim/base.nix
+++ b/modules/neovim/base.nix
@@ -87,6 +87,12 @@
       options.desc = "Live grep";
     }
     {
+      key = "<Leader>gs";
+      mode = "n";
+      action = "<Cmd>Telescope git_status<CR>";
+      options.desc = "Git status";
+    }
+    {
       key = "<Leader>ld";
       mode = "n";
       action = "<Cmd>Glance definitions<CR>";


### PR DESCRIPTION
## 概要

- Neovim に `<leader>gs` → `Telescope git_status` のキーバインドを追加した
- git の変更ファイルをインタラクティブに確認・操作できるようにするための変更
- 既存の Telescope キーバインド（`fb` / `fr` / `fg`）と同じパターンで実装しており、影響範囲は `modules/neovim/base.nix` のみ

## 確認事項

- `nixfmt` を適用し、フォーマットが正常であることを確認
- `home-manager build --flake .#testuser` でビルドが通ることを確認
- `<leader>gs` は既存のキーマップと競合しないことを確認（CI の `check-keymaps.lua` が重複を検出する仕組みになっている）

🤖 Generated with Claude Code