### PR TITLE
fix: Neovim の live grep で日本語検索できるようにする

### DIFF
--- a/modules/neovim/plugins.nix
+++ b/modules/neovim/plugins.nix
@@ -118,7 +118,14 @@
         };
         pickers = {
           find_files.hidden = true;
-          live_grep.only_sort_text = true;
+          grep_string.sorter = lib.nixvim.mkRaw "require('telescope.sorters').empty()";
+          live_grep = {
+            only_sort_text = true;
+            # ripgrep already does the actual filtering. Avoid Telescope's
+            # secondary fuzzy matcher here so multibyte queries such as
+            # Japanese text are not filtered out after rg finds them.
+            sorter = lib.nixvim.mkRaw "require('telescope.sorters').empty()";
+          };
         };
       };
     };


### PR DESCRIPTION
## 概要
- Neovim の Telescope `live_grep` / `grep_string` で、日本語のような多バイト文字クエリを後段の fuzzy sorter が落としてしまう問題を修正しました
- grep picker では `ripgrep` を検索本体として使っているため、Telescope 側の二段目 sorter を無効化して `rg` の結果をそのまま表示するように変更しました
- 影響範囲は `modules/neovim/plugins.nix` の Telescope picker 設定です

## 確認事項
- `ripgrep` 自体は UTF-8 の日本語を正常に検索できることを確認し、問題が Telescope 側の後段フィルタにあることを切り分けました
- `nixfmt modules/neovim/plugins.nix` を実行し、対象ファイルの整形を確認しました
- `home-manager build --flake .#testuser` を実行し、変更後の Nix 設定がビルドできることを確認しました
- 対話 UI 上での手動確認はこの環境では未実施です

## 補足
- fuzzy sorter を無効化するため、grep picker では Telescope 独自の曖昧絞り込みではなく `ripgrep` の検索結果をそのまま扱います

🤖 Generated with Codex