### PR TITLE
fix(claude): デフォルトの effort レベルを medium に変更

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -43,7 +43,7 @@
     "OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE": "delta",
     "OTEL_LOG_TOOL_DETAILS": "1"
   },
-  "effortLevel": "low",
+  "effortLevel": "medium",
   "permissions": {
     "defaultMode": "default",
     "allow": [


### PR DESCRIPTION
## 概要

- `config/claude/settings.json` の `effortLevel` を `"low"` から `"medium"` に変更
- `low` では応答が簡素になりすぎるため、より適切なデフォルト値に引き上げる

## 確認事項

- 変更は `effortLevel` の値のみで、他の設定への影響はない
- 設定値の変更のみのため、追加の動作検証は不要と判断

🤖 Generated with Claude Code