### PR TITLE
fix: semver-coerced を使うよう Renovate regex manager を修正

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,7 +36,7 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\s+version = \"(?<currentValue>[^\"]+)\";"
       ],
-      "versioningTemplate": "semver",
+      "versioningTemplate": "semver-coerced",
       "extractVersionTemplate": "^v?(?<version>.*)$"
     }
   ]


### PR DESCRIPTION
## 概要
- `renovate.json` の `customManagers` で使う `versioningTemplate` を `semver` から `semver-coerced` に変更しました
- GitHub Releases のタグ表記揺れで regex manager の更新検出が止まりにくい設定にしています

## 確認事項
- `jq empty renovate.json` で JSON として妥当であることを確認しました
- `npx --yes renovate --platform=local --dry-run=full` を実行し、`regex` manager で 3 件の依存抽出が継続して成功することを確認しました
- dry-run では GitHub token 未設定の警告は出ましたが、設定エラーや抽出失敗はありませんでした

🤖 Generated with Codex
