### PR TITLE
Adjust Renovate stability wait behavior

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,11 +17,12 @@
         "action"
       ],
       "pinDigests": true,
-      "minimumReleaseAge": "6 days",
-      "internalChecksFilter": "strict",
-      "prCreation": "not-pending",
+      "minimumReleaseAge": "7 days",
+      "minimumReleaseAgeBehaviour": "timestamp-required",
+      "internalChecksFilter": "none",
+      "prCreation": "immediate",
       "rebaseWhen": "never",
-      "schedule": [
+      "automergeSchedule": [
         "on sunday"
       ]
     }


### PR DESCRIPTION
## Summary
- create Renovate PRs immediately for GitHub Actions updates instead of waiting for internal stability checks
- keep a 7-day minimum release age and require timestamps for stability checks
- move the Sunday restriction from PR creation to automerge timing

## Verification
- jq empty renovate.json
- gitleaks pre-commit hook passed during commit