### PR TITLE
fix(neovim): ts_ls の typescript-language-server を Nix で自動インストールする

### DIFF
--- a/modules/neovim/lsp.nix
+++ b/modules/neovim/lsp.nix
@@ -59,7 +59,6 @@
         };
         ts_ls = {
           enable = true;
-          package = null;
         };
       };
     };


### PR DESCRIPTION
## 概要

- `ts_ls` LSP サーバーの `package = null` 設定を削除し、Nix による自動インストールに変更
- 以前は PATH 上の `typescript-language-server` に依存していたため、devShell に含まれていない環境（例: `templates/seichi-portal-frontend`）では LSP が起動できず `gd` などが機能しなかった
- Nix で管理することで環境依存をなくし、どのプロジェクトでも TSX/TypeScript の LSP が動作するようになる

## 確認事項

- 変更は `package = null` の1行削除のみで、nixvim のデフォルト（nixpkgs の `nodePackages.typescript-language-server` を使用）に委ねる形になる
- `home-manager build` での動作確認は未実施（CI で確認予定）

🤖 Generated with Claude Code