### PR TITLE
fix(codex): デフォルトのモデル選択に委ねる

### DIFF
--- a/modules/codex.nix
+++ b/modules/codex.nix
@@ -76,14 +76,11 @@ let
     builtins.concatStringsSep "\n" (map renderPrefixRule allowCommandPrefixes) + "\n"
   );
   codexConfig = {
-    model = "gpt-5.4";
     model_reasoning_effort = "medium";
     sandbox_mode = "workspace-write";
     sandbox_workspace_write.writable_roots = [ "/tmp" ];
 
     projects."${homeDirectory}".trust_level = "trusted";
-
-    notice.model_migrations."gpt-5.3-codex" = "gpt-5.4";
 
     tui.status_line = [
       "model-with-reasoning"


### PR DESCRIPTION
## 概要
- Codex の `model` 設定を削除し、CLI 側のデフォルトモデル選択に委ねるように変更
- `gpt-5.4` 前提だった `notice.model_migrations` も削除し、既定モデル変更への追従を設定側で妨げないように整理

## 確認事項
- `nixfmt modules/codex.nix` を実行し、対象ファイルを整形済み
- `home-manager build --flake .#testuser` を実行し、この設定変更で Home Manager のビルドが成功することを確認

🤖 Generated with Codex