### PR TITLE
fix(difit): fetchPnpmDeps を fetcherVersion 3 に移行する

### DIFF
--- a/modules/npm/packages/difit.nix
+++ b/modules/npm/packages/difit.nix
@@ -12,7 +12,7 @@ let
     pname = "difit";
     inherit version src;
     fetcherVersion = 3;
-    hash = "sha256-EIugUnOyVDZ7tWXeoUdYcp0q4xaEKeC+Hx3yIL0UGbs=";
+    hash = "sha256-LaKAgA2O+z670LLz+HqOehXblFH1T2hY3s6GUKezR0w=";
   };
 in
 pkgs.stdenv.mkDerivation {

--- a/modules/npm/packages/difit.nix
+++ b/modules/npm/packages/difit.nix
@@ -11,8 +11,8 @@ let
   pnpmDeps = pkgs.fetchPnpmDeps {
     pname = "difit";
     inherit version src;
-    fetcherVersion = 2;
-    hash = "sha256-oY0QGktG0PZ4Wq6/G6hxWko+HxkyRjkSDecV/ec6q7M=";
+    fetcherVersion = 3;
+    hash = "sha256-EIugUnOyVDZ7tWXeoUdYcp0q4xaEKeC+Hx3yIL0UGbs=";
   };
 in
 pkgs.stdenv.mkDerivation {


### PR DESCRIPTION
## 概要

- `difit.nix` の `fetchPnpmDeps` を `fetcherVersion = 2` から `fetcherVersion = 3` に移行した
- nixpkgs の更新によって `pkgs.pnpm` が v10 → v11 に上がると、v10 時代にビルドされた pnpm-deps キャッシュが pnpm v11 のオフラインインストールと非互換になり flake.lock 更新 PR の CI が高確率で落ちていた（`ERR_PNPM_NO_OFFLINE_TARBALL`）
- `fetcherVersion = 3` は pnpm store を zstd tarball 化する形式で、pnpm major バージョン跨ぎの互換性問題を回避する。また `fetcherVersion = 1/2` は nixpkgs 26.11 で削除予定のため必須対応でもある

## 確認事項

- `home-manager build --flake .#testuser` が正常終了することを確認済み
- `pnpmDeps.hash` を `""` にしてビルドし、出力された正しいハッシュ値に更新した

## 補足

- この PR は PR #366（flake.lock 更新 PR）の根本原因の修正。この PR がマージされれば #366 の CI も通るはず
- `fetcherVersion = 3` では Renovate による difit バージョン更新時も同様にハッシュ再生成が必要だが、既存の `update-hashes` ジョブが対応しているため影響なし

🤖 Generated with Claude Code