### PR TITLE
fix(difit): pnpm v11 向けに pnpmDeps ハッシュを再生成する

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -162,11 +162,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1777954456,
-        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {

--- a/modules/npm/packages/difit.nix
+++ b/modules/npm/packages/difit.nix
@@ -12,7 +12,7 @@ let
     pname = "difit";
     inherit version src;
     fetcherVersion = 3;
-    hash = "sha256-LaKAgA2O+z670LLz+HqOehXblFH1T2hY3s6GUKezR0w=";
+    hash = "sha256-SUnURxQ1hnLt30pINv0gaBHcIuzmqCt9u9sk8e2P91c=";
   };
 in
 pkgs.stdenv.mkDerivation {


### PR DESCRIPTION
## 概要

- nixpkgs `d233902`（2026-05-15）で `pkgs.pnpm` が v10 → v11 に更新されたことに伴い、difit の `pnpmDeps.hash` を pnpm v11 で再生成した
- `fetcherVersion = 3` の tarball は pnpm のメジャーバージョン跨ぎで内容が変わるため、nixpkgs が v10 → v11 になるたびにハッシュの再生成が必要
- flake.lock も同 nixpkgs リビジョン（d233902）に合わせて更新している

## 確認事項

- `home-manager build --flake .#testuser` が正常終了することを確認済み（pnpm v11 環境下）
- このブランチがマージされれば、flake.lock 更新 PR（`update_flake_lock_action`）の CI も通るはず

## 補足

- 根本原因と fetcherVersion = 3 への移行は PR #367 で対処済み
- pnpm がメジャーバージョンアップするたびに同様の再生成が必要になるため、renovate の `update-hashes` ジョブが pnpmDeps.hash も更新できるよう整備することを今後の課題としたい

🤖 Generated with Claude Code