### PR TITLE
docs(git-commit): スキルが自動発火しやすいよう description を強化する

### DIFF
--- a/config/agents/skills/git-commit/SKILL.md
+++ b/config/agents/skills/git-commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-commit
-description: AI Agent が git commit を行うためのスキル
+description: git commit を作成するときに必ず使用するスキル。ユーザーが「コミットして」「commit して」「変更を記録して」と言ったとき、または変更がまとまり commit すべきタイミングになったときに発火する。コンベンショナルコミット、日本語メッセージ、`--no-gpg-sign`、ブランチ確認、Co-author 付与などプロジェクト固有の必須ルールを含むため、エージェントが内蔵で持つ汎用的な commit 手順より**常にこのスキルを優先**すること。`git commit` を直接呼ぶ前に必ず参照する。
 ---
 
 # git commit スキル


### PR DESCRIPTION
## 概要
- `config/agents/skills/git-commit/SKILL.md` の description が「何をするスキルか」しか書かれておらず、エージェントの内蔵 commit 手順が優先されてスキルが自動発火しない事象があった
- 発火フレーズ、発火タイミング、内蔵手順より優先する旨、`git commit` 直前の必須参照、を明記して description を書き直す
- 特定エージェント名（Claude Code 等）を出さず、すべての対応エージェントに通る汎用表現に統一する

## 確認事項
- description テキストのみの変更で、スキル本体の手順や `home.nix` などの配備定義に影響しないことを確認
- home-manager 経由で `~/.claude/skills/git-commit/SKILL.md` および `~/.agents/skills/git-commit/SKILL.md` に反映される配置になっているため、ビルドや switch は不要と判断

## 補足
- 効果（実際に自動発火頻度が上がるか）は次回以降のコミット時に観測する。期待通りにならなければ `empirical-prompt-tuning` で更に詰める想定

🤖 Generated with Claude Code