### PR TITLE
Codex の auto review 設定を有効化する

### DIFF
--- a/modules/codex.nix
+++ b/modules/codex.nix
@@ -77,6 +77,8 @@ let
   );
   codexConfig = {
     model_reasoning_effort = "medium";
+    suppress_unstable_features_warning = true;
+    approvals_reviewer = "auto_review";
     sandbox_mode = "workspace-write";
     sandbox_workspace_write.writable_roots = [ "/tmp" ];
 


### PR DESCRIPTION
## 概要
- Codex の設定生成元で suppress_unstable_features_warning を有効化しました。
- approvals_reviewer を auto_review に設定し、承認レビュー担当を明示しました。
- 影響範囲は home-manager で配備される ~/.codex/config.toml です。

## 確認事項
- nixfmt modules/codex.nix を実行し、Nix ファイルの整形が完了しています。
- home-manager build --flake .#testuser が成功し、Codex config を含む Home Manager 世代を生成できることを確認しました。
- コミット時の gitleaks フックで no leaks を確認しました。

🤖 Generated with Codex