### PR TITLE
Claude Code に ccgate hook を追加する

### DIFF
--- a/config/claude/README.md
+++ b/config/claude/README.md
@@ -25,6 +25,13 @@
 - 実際に有効なルールは `settings.json` を正とする
 - `config/AGENTS.md`、`config/claude/AGENTS.md`、`settings.json` に関わる変更では、説明と実装の不整合を残さない
 
+## ccgate
+
+Claude Code の `PermissionRequest` hook には `ccgate claude` を登録します。  
+`ccgate` は Claude Code の静的 permission で解決できなかった実行可否を LLM に委譲し、明確に判断できない場合は Claude Code 側の通常の確認へ戻します。
+
+`ccgate` 自体は Nix package として配備し、API key はリポジトリに置かず `CCGATE_ANTHROPIC_API_KEY` などの環境変数で渡します。ログと metrics は既定で `$XDG_STATE_HOME/ccgate/claude/` に出力されます。
+
 ## 変更時の観点
 
 - `allow` に追加するコマンドは、本当に無確認実行で安全か

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -3,6 +3,17 @@
     "enabled": true
   },
   "hooks": {
+    "PermissionRequest": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ccgate claude"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",

--- a/modules/packages/ccgate.nix
+++ b/modules/packages/ccgate.nix
@@ -1,0 +1,35 @@
+{ pkgs }:
+
+pkgs.buildGoModule rec {
+  pname = "ccgate";
+  # renovate: datasource=github-releases depName=tak848/ccgate
+  version = "0.9.1";
+
+  src = pkgs.fetchFromGitHub {
+    owner = "tak848";
+    repo = "ccgate";
+    rev = "v${version}";
+    hash = "sha256-kHTOgJE+zMeLZFk//kSqhq4iYXEPZ3IK0fNF80VNv34=";
+  };
+
+  vendorHash = "sha256-Uw/ZS7MVTxPhvv6M3vop27q97RNmu0S1VhXiQ4Fj02c=";
+
+  subPackages = [ "." ];
+
+  nativeCheckInputs = [
+    pkgs.git
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${version}"
+  ];
+
+  meta = {
+    description = "LLM-powered PermissionRequest hook for coding agents";
+    homepage = "https://github.com/tak848/ccgate";
+    license = pkgs.lib.licenses.mit;
+    mainProgram = "ccgate";
+  };
+}


### PR DESCRIPTION
## 概要
- Claude Code の PermissionRequest hook に ccgate を登録し、静的 permission で解決できない実行可否を ccgate に委譲できるようにしました。
- ccgate v0.9.1 を Nix package として追加し、Home Manager 経由で PATH に載る構成にしました。
- `config/claude/README.md` に ccgate の運用方針、API key 管理、ログ出力先を追記しました。

## 確認事項
- `nixfmt modules/packages/ccgate.nix` を実行し、追加した Nix file の formatting を確認しました。
- `jq . config/claude/settings.json` を実行し、Claude Code settings の JSON として妥当であることを確認しました。
- `nix build path:/home/rito528/dotfiles#ccgate --no-link` で ccgate package が flake attr としてビルドできることを確認しました。
- `./result/bin/ccgate --version` で package された ccgate が `0.9.1` として実行できることを確認しました。
- `home-manager build --flake path:/home/rito528/dotfiles#testuser` で Home Manager 構成が評価・ビルドできることを確認しました。

## 補足
- 検証時点では `modules/packages/ccgate.nix` が未追跡だったため、通常の `.#ccgate` ではなく `path:/home/rito528/dotfiles#ccgate` で flake source に含めて確認しました。
- ccgate の API key はリポジトリには置かず、`CCGATE_ANTHROPIC_API_KEY` などの環境変数で渡す前提です。

🤖 Generated with Codex
