### PR TITLE
feat(claude): sandbox を有効化し git を sandbox 外で実行するよう設定する

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -2,6 +2,13 @@
   "worktreeConfig": {
     "enabled": true
   },
+  "sandbox": {
+    "enabled": true,
+    "autoAllowBashIfSandboxed": true,
+    "excludedCommands": [
+      "git *"
+    ]
+  },
   "hooks": {
     "PreToolUse": [
       {

--- a/modules/packages.nix
+++ b/modules/packages.nix
@@ -15,6 +15,7 @@
     fzf
     editorconfig-checker
     bubblewrap
+    socat
     yazi
   ];
 }


### PR DESCRIPTION
## 概要

- `config/claude/settings.json` に sandbox 設定を追加し、bubblewrap による sandbox を有効化
- `git *` コマンドを `excludedCommands` に指定し、git 操作が sandbox の制約を受けないよう設定
- `modules/packages.nix` に `socat` を追加（sandbox の動作に必要な依存パッケージ）

## 確認事項

- `nixfmt` を適用済みで、フォーマット上の問題なし
- `autoAllowBashIfSandboxed: true` により、sandbox 内の bash コマンドは既存の permissions 設定に従って動作する
- `bubblewrap` はすでに packages.nix に存在しており、`socat` を追加するだけで依存が揃う
- `home-manager switch` 後に有効になる設定変更のため、ビルド結果の事前確認は省略

## 補足

- sandbox から外れた場合（`excludedCommands` 該当時）は、現行の `permissions` の allow/deny ルールがそのまま適用される

🤖 Generated with Claude Code