### PR TITLE
fix(claude): sandbox に GitHub ドメインを許可し未使用の otel 設定を削除する

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -7,7 +7,13 @@
     "autoAllowBashIfSandboxed": true,
     "excludedCommands": [
       "git *"
-    ]
+    ],
+    "network": {
+      "allowedDomains": [
+        "api.github.com",
+        "github.com"
+      ]
+    }
   },
   "hooks": {
     "PreToolUse": [
@@ -40,15 +46,6 @@
   "enabledPlugins": {
     "rust-analyzer-lsp@claude-plugins-official": true,
     "example-skills@anthropic-agent-skills": true
-  },
-  "env": {
-    "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
-    "OTEL_METRICS_EXPORTER": "otlp",
-    "OTEL_LOGS_EXPORTER": "otlp",
-    "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc",
-    "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
-    "OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE": "delta",
-    "OTEL_LOG_TOOL_DETAILS": "1"
   },
   "effortLevel": "medium",
   "permissions": {


### PR DESCRIPTION
## 概要

- `sandbox.network.allowedDomains` に `api.github.com` と `github.com` を追加し、sandbox 有効時に GitHub 関連の通信が遮断されていた問題を解消する
- `localhost:4317` を向いている OTEL 設定（`CLAUDE_CODE_ENABLE_TELEMETRY` および `OTEL_*` 環境変数）はコレクターが存在しない環境では機能しないため全削除する

## 確認事項

- `config/claude/settings.json` の JSON 構文に問題がないことを diff で確認済み
- sandbox の `network.allowedDomains` は許可ドメインのみを列挙する設定であり、他のドメインへの通信制限には影響しない

## 補足

- otel 設定を再び有効化する場合はコレクターのエンドポイントとともに追加し直すこと

🤖 Generated with Claude Code