### PR TITLE
feat(claude): デフォルトの permission モードを auto に変更する

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -49,7 +49,7 @@
   },
   "effortLevel": "medium",
   "permissions": {
-    "defaultMode": "default",
+    "defaultMode": "auto",
     "allow": [
       "Bash(grep *)",
       "Bash(rg *)",


### PR DESCRIPTION
## 概要

- `config/claude/settings.json` の `permissions.defaultMode` を `"default"` から `"auto"` に変更した
- 確認プロンプトの頻度を減らし、作業をよりスムーズに進めるための設定変更

## 確認事項

- 変更は `permissions.defaultMode` の値を 1 箇所書き換えるだけであり、他の `allow` / `ask` / `deny` ルールには影響しない
- 既存の明示的な `allow` / `deny` / `ask` ルールは引き続き有効で、動作の境界は変わらない

## 補足

- auto モードは Claude Code の組み込み安全境界（ハードブロック）を維持したまま確認プロンプトを減らすモード
- `disableAutoMode` は設定していないため、必要に応じてセッション内で切り替え可能

🤖 Generated with Claude Code