### PR TITLE
fix(neovim): LSP サーバーのパッケージを Nix で自動管理する

### DIFF
--- a/modules/neovim/lsp.nix
+++ b/modules/neovim/lsp.nix
@@ -40,22 +40,18 @@
       servers = {
         eslint = {
           enable = true;
-          package = null;
           settings.eslint.autoFixOnSave = true;
         };
         jsonls = {
           enable = true;
-          package = null;
         };
         rust_analyzer = {
           enable = true;
           installCargo = false;
           installRustc = false;
-          package = null;
         };
         taplo = {
           enable = true;
-          package = null;
         };
         ts_ls = {
           enable = true;


### PR DESCRIPTION
## 概要

- `modules/neovim/lsp.nix` の `eslint`、`jsonls`、`rust_analyzer`、`taplo` の各 LSP サーバーで `package = null` が設定されており、Nix がバイナリをインストールしないため PATH に存在しない状態だった
- JSON ファイルを nvim で開くと `vscode-json-language-server` が見つからないエラーが発生していた（他の LSP も同様）
- 各サーバーの `package = null` を削除し、nixvim にパッケージのインストールを委ねることで解消する
- `rust_analyzer` は `installCargo = false; installRustc = false;` を維持し、Cargo/Rustc ツールチェーンは引き続き rustup 管理とする

## 確認事項

- `home-manager build --flake .#testuser` が成功することを確認（`rust-analyzer-2026-04-27` などのダウンロードも確認）
- `nixfmt` 適用済み

## 補足

`ts_ls` は元々 `package = null` なしで自動管理されており、影響なし。

🤖 Generated with Claude Code