### PR TITLE
Renovate の digest 更新を自動マージ可能にする

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,20 @@
       "automergeSchedule": [
         "on sunday"
       ]
+    },
+    {
+      "matchDepTypes": [
+        "action"
+      ],
+      "matchUpdateTypes": [
+        "digest",
+        "pinDigest"
+      ],
+      "minimumReleaseAge": null,
+      "minimumReleaseAgeBehaviour": "timestamp-optional",
+      "automergeSchedule": [
+        "on sunday"
+      ]
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## 概要
- GitHub Actions の digest / pinDigest 更新だけ `minimumReleaseAge` の対象から外し、`renovate/stability-days` で詰まらないようにしました。
- tag/version 更新は従来通り 7 日の stability-days を維持し、SHA pinning と日曜 automerge schedule は継続します。

## 確認事項
- `LOG_LEVEL=debug npx --yes renovate --platform=local --dry-run=full` で変更後の `renovate.json` が Renovate に読み込まれ、設定 validation エラーが出ないことを確認しました。
- dry-run は GitHub token なしの local platform 実行のため lookup warning は出ますが、今回の設定変更自体の妥当性には影響しません。
- コミット時の gitleaks hook で leak が検出されないことを確認しました。

## 補足
- 既存の Renovate PR の pending status は、この変更が main に入った後の次回 Renovate 実行または rebase/retry で更新される想定です。

🤖 Generated with Codex