### PR TITLE
feat: rito528-dotfiles Cachix キャッシュを substituter として追加

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -21,6 +21,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+        with:
+          name: rito528-dotfiles
       - name: Check nixfmt formatting
         run: |
           find . -name "*.nix" -not -path "./.git/*" -type f | \

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,14 @@
   description = "Home Manager configuration";
 
   nixConfig = {
-    extra-substituters = [ "https://cache.numtide.com" ];
-    extra-trusted-public-keys = [ "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g=" ];
+    extra-substituters = [
+      "https://cache.numtide.com"
+      "https://rito528-dotfiles.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
+      "rito528-dotfiles.cachix.org-1:Kp/hDIx4sR31gHfT0z0D1RxjdpSrh47nHqzOtDXL/mE="
+    ];
   };
 
   inputs = {


### PR DESCRIPTION
## 概要
- GHA の `integration-test` ワークフローでビルド・プッシュされる `rito528-dotfiles.cachix.org` を、ローカルおよび `nix-flake-check` ワークフローでも substituter として参照できるようにした
- `flake.nix` の `nixConfig` に substituter URL と公開鍵を追加（llm-agents 用の `cache.numtide.com` と同じ方式）
- `nix.yaml` に `cachix/cachix-action`（読み取り専用、authToken なし）を追加

## 確認事項
- `nixfmt --check flake.nix` でフォーマット違反なしを確認済み
- キャッシュは public であることを `curl https://rito528-dotfiles.cachix.org/nix-cache-info` で確認済み（authToken 不要）
- `integration-test.yaml` はすでに authToken 付きで push 済みのため変更なし

🤖 Generated with Claude Code