### PR TITLE
fix: Cachix キャッシュが non-trusted user で無視される問題を修正

### DIFF
--- a/install/common/nix.sh
+++ b/install/common/nix.sh
@@ -6,8 +6,12 @@ set -euo pipefail
 
 NUMTIDE_SUBSTITUTER="https://cache.numtide.com"
 NUMTIDE_PUBLIC_KEY="niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
+CACHIX_SUBSTITUTER="https://rito528-dotfiles.cachix.org"
+CACHIX_PUBLIC_KEY="rito528-dotfiles.cachix.org-1:Kp/hDIx4sR31gHfT0z0D1RxjdpSrh47nHqzOtDXL/mE="
 
-configure_numtide_cache() {
+# extra-trusted-substituters はシステム nix.conf に書く必要がある。
+# flake.nix の nixConfig による extra-substituters は trusted user でないと無視されるため。
+configure_nix_caches() {
     local nix_conf="/etc/nix/nix.conf"
     local nix_custom_conf="/etc/nix/nix.custom.conf"
     local target_conf="$nix_conf"
@@ -18,21 +22,25 @@ configure_numtide_cache() {
         sudo touch "$target_conf"
     fi
 
-    if grep -qF "$NUMTIDE_SUBSTITUTER" "$target_conf" 2>/dev/null; then
-        echo "Numtide cache is already configured in $target_conf"
-    else
-        echo "Configuring Numtide cache in $target_conf..."
-        echo "extra-trusted-substituters = $NUMTIDE_SUBSTITUTER" | sudo tee -a "$target_conf" > /dev/null
-        restart_required=1
-    fi
+    for substituter in "$NUMTIDE_SUBSTITUTER" "$CACHIX_SUBSTITUTER"; do
+        if grep -qF "$substituter" "$target_conf" 2>/dev/null; then
+            echo "Cache substituter $substituter is already configured in $target_conf"
+        else
+            echo "Configuring cache substituter $substituter in $target_conf..."
+            echo "extra-trusted-substituters = $substituter" | sudo tee -a "$target_conf" > /dev/null
+            restart_required=1
+        fi
+    done
 
-    if grep -qF "$NUMTIDE_PUBLIC_KEY" "$target_conf" 2>/dev/null; then
-        echo "Numtide cache public key is already configured in $target_conf"
-    else
-        echo "Configuring Numtide cache public key in $target_conf..."
-        echo "extra-trusted-public-keys = $NUMTIDE_PUBLIC_KEY" | sudo tee -a "$target_conf" > /dev/null
-        restart_required=1
-    fi
+    for key in "$NUMTIDE_PUBLIC_KEY" "$CACHIX_PUBLIC_KEY"; do
+        if grep -qF "$key" "$target_conf" 2>/dev/null; then
+            echo "Cache public key is already configured in $target_conf"
+        else
+            echo "Configuring cache public key in $target_conf..."
+            echo "extra-trusted-public-keys = $key" | sudo tee -a "$target_conf" > /dev/null
+            restart_required=1
+        fi
+    done
 
     if [ "$restart_required" -eq 1 ]; then
         echo "Restarting nix-daemon to apply cache settings..."
@@ -42,7 +50,7 @@ configure_numtide_cache() {
 
 if command -v nix &>/dev/null || [ -e /nix/var/nix/profiles/default/bin/nix ]; then
     echo "Nix is already installed"
-    configure_numtide_cache
+    configure_nix_caches
     exit 0
 fi
 
@@ -55,7 +63,7 @@ else
         | sh -s -- install --no-confirm
 fi
 
-configure_numtide_cache
+configure_nix_caches
 
 echo "Nix installation complete."
 echo "Please restart your shell or run: . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh"


### PR DESCRIPTION
## 概要
- `flake.nix` の `nixConfig` に追加した `extra-substituters` は、Nix の trusted user でないと無視される仕様のため、`setup.sh` 実行時に warning が出てキャッシュが効いていなかった
- `install/common/nix.sh` で numtide と同様に `/etc/nix/nix.conf` へ `extra-trusted-substituters` として書き込む方式に統一した
- numtide と cachix の両キャッシュをループで処理するよう関数をリファクタリングし、`configure_nix_caches` に改名

## 確認事項
- `shellcheck` でエラーなしを確認済み
- `setup.sh` 実行時の warning（`ignoring untrusted substituter`）はこのスクリプトがシステム nix.conf を書き換えることで解消される

## 補足
- すでにセットアップ済みの環境では `setup.sh` の再実行または手動で `/etc/nix/nix.conf` に `extra-trusted-substituters = https://rito528-dotfiles.cachix.org` を追記する必要がある

🤖 Generated with Claude Code