### PR TITLE
ci: templates の flake.lock も自動更新する

### DIFF
--- a/.github/workflows/update-flake-lock.yaml
+++ b/.github/workflows/update-flake-lock.yaml
@@ -17,13 +17,41 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 
-      - uses: DeterminateSystems/update-flake-lock@c92eec5a0027bf5ab1523eee093a49c57b4ff388
-        with:
-          pr-title: 'deps: update flake.lock'
-          pr-labels: |
-            dependencies
-          path-to-flake-dir: '.'
-          token: ${{ steps.app-token.outputs.token }}
+      - name: Update all flake.locks
+        run: |
+          nix flake update
+          for dir in templates/*/; do
+            (cd "$dir" && nix flake update)
+          done
+
+      - name: Create PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add flake.lock
+          find templates -maxdepth 2 -name "flake.lock" -exec git add {} \;
+
+          if git diff --staged --quiet; then
+            echo "No changes detected"
+            exit 0
+          fi
+
+          branch="update-flake-lock"
+          git checkout -B "$branch"
+          git commit -m "deps: update flake.lock"
+          git push origin "$branch" --force
+
+          gh pr create \
+            --title "deps: update flake.lock" \
+            --body "Weekly automated flake.lock updates for root flake and templates." \
+            --label "dependencies" \
+            --base main \
+            --head "$branch" 2>/dev/null || echo "PR already exists, branch updated"


### PR DESCRIPTION
## 概要
- `DeterminateSystems/update-flake-lock` はルートの `flake.lock` しか対象にできないため、カスタムステップに置き換えた
- ルートと `templates/*/` の全 `flake.lock` を `nix flake update` で更新し、変更があれば `update-flake-lock` ブランチに1つの PR としてまとめてプッシュするよう変更
- `flake.lock` が存在しないテンプレートは初回実行時に新規作成される（これにより devShell の cachix キャッシュが正しく機能するようになる）

## 確認事項
- workflow の構文はシンプルな bash スクリプトと既存アクションの組み合わせであり、ロジックはローカルで確認済み
- 実際の flake update と PR 作成は CI 上でのみ動作確認可能なため、初回は workflow_dispatch で手動トリガーして動作を確認することを推奨

## 補足
- actions/checkout に token を渡すよう追加した（これがないと force push が失敗する）
- 同名ブランチが既に存在する場合は force push でブランチを更新し、PR 作成は 2>/dev/null || echo でスキップする

🤖 Generated with Claude Code