### PR TITLE
fix(codex): config.toml を mutable なコピーとして配置し Codex の書き込みを許可する

### DIFF
--- a/modules/codex.nix
+++ b/modules/codex.nix
@@ -1,5 +1,6 @@
 {
   pkgs,
+  lib,
   homeDirectory,
   ...
 }:
@@ -97,12 +98,16 @@ let
 
     features.codex_git_commit = true;
   };
+  codexConfigFile = tomlFormat.generate "codex-config.toml" codexConfig;
 in
 {
-  home.file.".codex/config.toml" = {
-    force = true;
-    source = tomlFormat.generate "codex-config.toml" codexConfig;
-  };
+  # config.toml は Codex がトラスト設定などを書き込むため、symlink ではなく
+  # mutable なコピーとして配置する。home-manager switch のたびに上書きされる。
+  home.activation.codexConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    $DRY_RUN_CMD mkdir -p "${homeDirectory}/.codex"
+    $DRY_RUN_CMD cp -f ${codexConfigFile} "${homeDirectory}/.codex/config.toml"
+    $DRY_RUN_CMD chmod 644 "${homeDirectory}/.codex/config.toml"
+  '';
 
   home.file.".codex/rules/default.rules" = {
     force = true;


### PR DESCRIPTION
## 概要

- `home.file` で `~/.codex/config.toml` を管理すると Nix ストアへの symlink になり読み取り専用となる
- Codex がプロジェクトのトラスト設定を書き込もうとすると `config/batchWrite failed in TUI` エラーが発生し開けなくなる
- `home.activation` でコピーとして配置するよう変更し、Codex が書き込めるようにした
- `home-manager switch` のたびにリポジトリの内容で上書きされるため、宣言的管理は維持される

## 確認事項

- `home-manager build --flake .#testuser` が正常に完了することを確認済み
- `nixfmt` 適用済み

## 補足

- `rules/default.rules` は Codex が書き込まないため、引き続き `home.file`（symlink）のまま
- home-manager には「symlink ではなくコピーとして配置する」ネイティブオプションは存在せず、`home.activation` が唯一の標準的手段

🤖 Generated with Claude Code