### PR TITLE
fix(codex): install で既存 symlink を正しく mutable ファイルへ置き換える

### DIFF
--- a/modules/codex.nix
+++ b/modules/codex.nix
@@ -105,8 +105,7 @@ in
   # mutable なコピーとして配置する。home-manager switch のたびに上書きされる。
   home.activation.codexConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     $DRY_RUN_CMD mkdir -p "${homeDirectory}/.codex"
-    $DRY_RUN_CMD cp -f ${codexConfigFile} "${homeDirectory}/.codex/config.toml"
-    $DRY_RUN_CMD chmod 644 "${homeDirectory}/.codex/config.toml"
+    $DRY_RUN_CMD install -m 644 ${codexConfigFile} "${homeDirectory}/.codex/config.toml"
   '';
 
   home.file.".codex/rules/default.rules" = {


### PR DESCRIPTION
## 概要

- #393 で `home.activation` による `cp -f` に変更したが、`~/.codex/config.toml` が旧 `home.file` 管理の symlink のまま残っている環境では `cp` が「コピー元と同一 inode」と判断し "same file" エラーで失敗することが判明
- `install` はコピー先が symlink でも新規ファイルとして作成するため、この問題を回避できる
- `cp -f` + `chmod 644` の 2 行を `install -m 644` の 1 行に置き換えた

## 確認事項

- `home-manager build --flake .#testuser` が正常に完了することを確認済み
- 実環境では `home-manager switch` 後に `~/.codex/config.toml` が通常ファイルに切り替わることで Codex のトラスト設定書き込みが通るようになる

🤖 Generated with Claude Code