### PR TITLE
fix(ci): modules/packages/ 廃止後のハッシュ更新ワークフローを修正する

### DIFF
--- a/.github/workflows/nix-update-pr.yaml
+++ b/.github/workflows/nix-update-pr.yaml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     paths:
       - 'modules/npm/packages/*.nix'
-      - 'modules/packages/*.nix'
+      - 'modules/*.nix'
 
 jobs:
   update-hashes:
@@ -29,19 +29,37 @@ jobs:
 
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 
-      - name: Update hashes for changed nix files
+      - name: Update hashes for npm packages
         run: |
-          changed=$(git diff --name-only origin/main HEAD -- 'modules/npm/packages/*.nix' 'modules/packages/*.nix')
+          changed=$(git diff --name-only origin/main HEAD -- 'modules/npm/packages/*.nix')
           for f in $changed; do
             pkg=$(basename "$f" .nix)
             echo "Updating hashes for ${pkg}..."
             nix run nixpkgs#nix-update -- --version=skip --flake "${pkg}"
           done
 
+      - name: Update hashes for module packages
+        run: |
+          changed=$(git diff --name-only origin/main HEAD -- 'modules/*.nix')
+          for f in $changed; do
+            grep -q '# renovate:' "${f}" || continue
+
+            version=$(grep -oP 'version = "\K[^"]+' "${f}" | head -1)
+            url=$(grep -oP 'url = "\K[^"]+' "${f}" | head -1 | sed "s/\\\${version}/${version}/g")
+            [ -n "${url}" ] || continue
+
+            echo "Fetching hash for ${f} (${url})..."
+            new_hash=$(nix store prefetch-file --hash-type sha256 --json "${url}" | jq -r '.hash')
+            [ -n "${new_hash}" ] && [ "${new_hash}" != "null" ] || continue
+
+            sed -i "s|hash = \"sha256-[^\"]*\"|hash = \"${new_hash}\"|" "${f}"
+            echo "Updated hash in ${f}: ${new_hash}"
+          done
+
       - name: Commit updated hashes
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add modules/npm/packages/ modules/packages/
+          git add modules/npm/packages/ modules/
           git diff --staged --quiet || git commit -m "chore: update nix hashes for renovate bump"
           git push


### PR DESCRIPTION
## 概要

- `modules/packages/` 廃止（3e98212）以降、`nix-update-pr.yaml` がその変更に追従できておらず2つのCIが壊れていた
- `git add modules/packages/` で存在しないパスを指定していたため exit 128 → npm パッケージのハッシュ更新がコミットされない（PR #398 原因）
- `modules/*.nix`（`git-wt.nix` 等）がパストリガー対象外のため、Renovate でバージョンだけ上がってもハッシュが更新されない（PR #400 原因）

変更点:
- パストリガーを `modules/packages/*.nix` → `modules/*.nix` に変更
- `modules/*.nix` 向けのハッシュ更新ステップを追加（`# renovate:` コメントがあるファイルのみ `nix store prefetch-file` でハッシュを更新）
- `git add` の `modules/packages/` → `modules/` に修正

## 確認事項

- `shellcheck` で追加した bash スクリプトを検証済み（エラーなし）
- `modules/shell.nix` などの Renovate 非対象ファイルは `grep -q '# renovate:'` でスキップされることをコード上で確認
- PR #398 / #400 のブランチで CI を再トリガーして動作検証予定（本 PR マージ後）

## 補足

- `nix-update --flake` は flake パッケージとして公開された derivation にしか使えないため、`modules/*.nix`（home-manager モジュール）には `nix store prefetch-file` で代替した
- difit (`modules/npm/packages/difit.nix`) の `pnpmDeps.hash` 更新は既存の `nix-update --flake difit` に委ねており、v5.0.1→v5.0.2 では pnpm-lock.yaml 変更がなく Integration Test は通過している

🤖 Generated with Claude Code