### PR TITLE
Renovate の automerge を日曜スケジュールに従わせる

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
   ],
   "automerge": true,
   "automergeType": "pr",
-  "platformAutomerge": true,
+  "platformAutomerge": false,
   "updateNotScheduled": false,
   "packageRules": [
     {


### PR DESCRIPTION
## 概要
- Renovate の `platformAutomerge` を無効化し、GitHub native auto-merge ではなく Renovate 自身が merge するように変更します。
- 既存の `automergeSchedule: ["on sunday"]` を Renovate 側で評価させ、日曜以外に platform 側で即時 merge される挙動を避けます。

## 確認事項
- `jq empty renovate.json` で JSON として妥当なことを確認しました。
- `npx --yes renovate --platform=local --dry-run=full` で Renovate 設定の読み込みと依存抽出が成功することを確認しました。GitHub token なしによる rate limit warning は出ていますが、今回の設定変更自体は valid です。
- commit 時の gitleaks check で secret が検出されないことを確認しました。

🤖 Generated with Codex