### PR TITLE
ci: flake lock 更新 PR の自動マージを有効化

### DIFF
--- a/.github/workflows/update-flake-lock.yaml
+++ b/.github/workflows/update-flake-lock.yaml
@@ -9,6 +9,9 @@ jobs:
   update-flake-lock:
     name: Update flake.lock
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token
@@ -55,3 +58,5 @@ jobs:
             --label "dependencies" \
             --base main \
             --head "$branch" 2>/dev/null || echo "PR already exists, branch updated"
+
+          gh pr merge "$branch" --auto --squash --delete-branch


### PR DESCRIPTION
## 概要
- 週次の flake.lock 更新 workflow が作成する PR に対して、GitHub auto-merge を有効化するようにしました。
- workflow job に `contents: write` と `pull-requests: write` を明示し、PR 作成後に `gh pr merge --auto --squash --delete-branch` を実行します。

## 確認事項
- `git diff --check` で空白エラーがないことを確認しました。
- Python の YAML パーサで `.github/workflows/update-flake-lock.yaml` が構文エラーなく読み込めることを確認しました。
- `gh pr merge --help` で `--auto`, `--squash`, `--delete-branch` が利用可能なオプションであることを確認しました。

🤖 Generated with Codex