### PR TITLE
fix(ci): flake lock 更新 PR の即時マージを防ぐ

### DIFF
--- a/.github/workflows/auto-merge-dependency-pr.yaml
+++ b/.github/workflows/auto-merge-dependency-pr.yaml
@@ -14,7 +14,10 @@ on:
 jobs:
   auto-merge:
     name: Auto Merge Dependency PRs
-    if: github.event.workflow_run.event == 'pull_request'
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_branch == 'update-flake-lock' &&
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/.github/workflows/auto-merge-dependency-pr.yaml
+++ b/.github/workflows/auto-merge-dependency-pr.yaml
@@ -1,0 +1,97 @@
+name: Auto Merge Dependency PRs
+
+on:
+  workflow_run:
+    workflows:
+      - Dev Shell
+      - EditorConfig
+      - Integration Test
+      - Lint
+      - Nix
+      - Renovate Config Check
+    types: [completed]
+
+jobs:
+  auto-merge:
+    name: Auto Merge Dependency PRs
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: read
+    steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Merge update-flake-lock PR after checks pass
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          prs=$(gh api "repos/${GH_REPO}/commits/${HEAD_SHA}/pulls" \
+            -H "Accept: application/vnd.github+json" \
+            --jq '.[].number')
+
+          for pr in ${prs}; do
+            state=$(gh pr view "${pr}" --json state --jq '.state')
+            base_ref=$(gh pr view "${pr}" --json baseRefName --jq '.baseRefName')
+            head_ref=$(gh pr view "${pr}" --json headRefName --jq '.headRefName')
+            is_draft=$(gh pr view "${pr}" --json isDraft --jq '.isDraft')
+            labels=$(gh pr view "${pr}" --json labels --jq '.labels[].name')
+
+            if [ "${state}" != "OPEN" ] \
+              || [ "${base_ref}" != "main" ] \
+              || [ "${head_ref}" != "update-flake-lock" ] \
+              || [ "${is_draft}" != "false" ] \
+              || ! printf '%s\n' "${labels}" | grep -qx 'dependencies'; then
+              continue
+            fi
+
+            previous_checks=''
+            stable_count=0
+            checks=''
+
+            for _ in $(seq 1 12); do
+              checks=$(gh pr checks "${pr}" --json name,bucket \
+                --jq 'sort_by(.name)[] | [.name, .bucket] | @tsv' || true)
+
+              if [ -n "${checks}" ] && [ "${checks}" = "${previous_checks}" ]; then
+                stable_count=$((stable_count + 1))
+              else
+                stable_count=0
+              fi
+
+              if [ "${stable_count}" -ge 2 ]; then
+                break
+              fi
+
+              previous_checks="${checks}"
+              sleep 10
+            done
+
+            if [ -z "${checks}" ]; then
+              echo "PR #${pr} has no checks yet; skipping merge."
+              continue
+            fi
+
+            if ! printf '%s\n' "${checks}" | awk -F '\t' '$2 == "pass" { found = 1 } END { exit found ? 0 : 1 }'; then
+              echo "PR #${pr} has no passing checks yet; skipping merge."
+              printf '%s\n' "${checks}"
+              continue
+            fi
+
+            if printf '%s\n' "${checks}" | awk -F '\t' '$2 == "pending" || $2 == "fail" || $2 == "cancel" { found = 1 } END { exit found ? 0 : 1 }'; then
+              echo "PR #${pr} still has pending, failing, or cancelled checks; skipping merge."
+              printf '%s\n' "${checks}"
+              continue
+            fi
+
+            gh pr merge "${pr}" --squash --delete-branch
+          done

--- a/.github/workflows/update-flake-lock.yaml
+++ b/.github/workflows/update-flake-lock.yaml
@@ -58,5 +58,3 @@ jobs:
             --label "dependencies" \
             --base main \
             --head "$branch" 2>/dev/null || echo "PR already exists, branch updated"
-
-          gh pr merge "$branch" --auto --squash --delete-branch


### PR DESCRIPTION
## 概要
- `update-flake-lock` workflow から PR 作成直後の `gh pr merge --auto` を削除しました。
- CI workflow の完了イベントを受けて、`update-flake-lock` ブランチの `dependencies` PR だけを対象にチェック状態を確認する auto-merge workflow を追加しました。
- チェック一覧が安定し、少なくとも pass があり、`pending` / `fail` / `cancel` がない場合だけ squash merge します。

## 確認事項
- `git diff --cached --check` で空白エラーがないことを確認しました。
- Python の YAML パーサで変更した workflow 2 件が構文エラーなく読み込めることを確認しました。
- 追加 workflow の `run:` ブロックを抽出して `shellcheck -s bash -` が通ることを確認しました。

## 補足
- PR #404 は既にマージ済みだったため、この PR は即時マージ挙動を止める後続修正です。

🤖 Generated with Codex