### PR TITLE
ci: ブランチ保護向けの CI gate を追加

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,140 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-24.04
+    outputs:
+      ci: ${{ steps.changes.outputs.ci }}
+      devshell: ${{ steps.changes.outputs.devshell }}
+      integration: ${{ steps.changes.outputs.integration }}
+      nix: ${{ steps.changes.outputs.nix }}
+      shell: ${{ steps.changes.outputs.shell }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed paths
+        id: changes
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+
+          base="$BASE_SHA"
+          head="$HEAD_SHA"
+
+          if [ "$EVENT_NAME" = "push" ] && [[ "$base" =~ ^0+$ ]]; then
+            base="${head}^"
+          fi
+
+          changed_files=$(git diff --name-only "$base" "$head")
+
+          ci=false
+          devshell=false
+          integration=false
+          nix=false
+          shell=false
+
+          while IFS= read -r file; do
+            [ -n "$file" ] || continue
+
+            case "$file" in
+              .github/workflows/*)
+                ci=true
+                ;;
+            esac
+
+            case "$file" in
+              *.nix|flake.lock)
+                nix=true
+                integration=true
+                ;;
+            esac
+
+            case "$file" in
+              config/*|install/*|modules/neovim/check-keymaps.lua)
+                integration=true
+                ;;
+            esac
+
+            case "$file" in
+              templates/*)
+                devshell=true
+                ;;
+            esac
+
+            case "$file" in
+              *.sh|install/*|config/*)
+                shell=true
+                ;;
+            esac
+          done <<< "$changed_files"
+
+          {
+            echo "ci=$ci"
+            echo "devshell=$devshell"
+            echo "integration=$integration"
+            echo "nix=$nix"
+            echo "shell=$shell"
+          } >> "$GITHUB_OUTPUT"
+
+  editorconfig:
+    name: EditorConfig
+    uses: ./.github/workflows/editorconfig.yaml
+
+  lint:
+    name: Lint
+    needs: changes
+    uses: ./.github/workflows/lint.yaml
+    with:
+      run-shellcheck: ${{ needs.changes.outputs.ci == 'true' || needs.changes.outputs.shell == 'true' }}
+
+  nix:
+    name: Nix
+    needs: changes
+    if: needs.changes.outputs.ci == 'true' || needs.changes.outputs.nix == 'true'
+    uses: ./.github/workflows/nix.yaml
+
+  integration-test:
+    name: Integration Test
+    needs: changes
+    if: needs.changes.outputs.ci == 'true' || needs.changes.outputs.integration == 'true'
+    uses: ./.github/workflows/integration-test.yaml
+    secrets: inherit
+
+  devshell:
+    name: Dev Shell
+    needs: changes
+    if: needs.changes.outputs.ci == 'true' || needs.changes.outputs.devshell == 'true'
+    uses: ./.github/workflows/devshell.yaml
+    secrets: inherit
+
+  ci-gate:
+    name: CI Gate
+    needs:
+      - changes
+      - editorconfig
+      - lint
+      - nix
+      - integration-test
+      - devshell
+    if: always()
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check required CI jobs
+        env:
+          RESULTS: ${{ toJson(needs.*.result) }}
+        run: |
+          set -euo pipefail
+
+          echo "$RESULTS" | jq -e 'all(.[]; . == "success" or . == "skipped")'

--- a/.github/workflows/devshell.yaml
+++ b/.github/workflows/devshell.yaml
@@ -1,16 +1,7 @@
 name: Dev Shell
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'templates/**'
-      - '.github/workflows/devshell.yaml'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'templates/**'
-      - '.github/workflows/devshell.yaml'
+  workflow_call:
 
 jobs:
   discover:
@@ -24,7 +15,7 @@ jobs:
       - name: List templates
         id: list
         run: |
-          templates=$(ls -1 templates/ | jq -Rc '[.,inputs]')
+          templates=$(find templates -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort | jq -Rc '[.,inputs]')
           echo "templates=$templates" >> "$GITHUB_OUTPUT"
 
   devshell-build:

--- a/.github/workflows/editorconfig.yaml
+++ b/.github/workflows/editorconfig.yaml
@@ -1,10 +1,7 @@
 name: EditorConfig
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_call:
 
 jobs:
   editorconfig:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -1,24 +1,7 @@
 name: Integration Test
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - '**/*.nix'
-      - 'flake.lock'
-      - 'config/**'
-      - 'install/**'
-      - 'modules/neovim/check-keymaps.lua'
-      - '.github/workflows/integration-test.yaml'
-  pull_request:
-    branches: [main]
-    paths:
-      - '**/*.nix'
-      - 'flake.lock'
-      - 'config/**'
-      - 'install/**'
-      - 'modules/neovim/check-keymaps.lua'
-      - '.github/workflows/integration-test.yaml'
+  workflow_call:
 
 jobs:
   integration-test:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,18 +1,12 @@
 name: Lint
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - '**/*.sh'
-      - 'config/**'
-      - '.github/workflows/lint.yaml'
-  pull_request:
-    branches: [main]
-    paths:
-      - '**/*.sh'
-      - 'config/**'
-      - '.github/workflows/lint.yaml'
+  workflow_call:
+    inputs:
+      run-shellcheck:
+        description: Run shellcheck when shell-related files changed.
+        required: true
+        type: boolean
 
 jobs:
   lint:
@@ -29,10 +23,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install shellcheck
+        if: inputs.run-shellcheck
         run: sudo apt-get install -y shellcheck
 
       - name: Run shellcheck
+        if: inputs.run-shellcheck
         run: |
-          find . -type f \( -name "*.sh" -o ! -name "*.*" \) \
-            | xargs grep -lE '^#!.*\b(bash|sh)\b' \
-            | xargs shellcheck
+          find . -type f \( -name "*.sh" -o ! -name "*.*" \) -print0 \
+            | xargs -0 -r grep -lZE '^#!.*\b(bash|sh)\b' \
+            | xargs -0 -r shellcheck

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -1,18 +1,7 @@
 name: Nix
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - '**/*.nix'
-      - 'flake.lock'
-      - '.github/workflows/nix.yaml'
-  pull_request:
-    branches: [main]
-    paths:
-      - '**/*.nix'
-      - 'flake.lock'
-      - '.github/workflows/nix.yaml'
+  workflow_call:
 
 jobs:
   nix-flake-check:
@@ -26,6 +15,6 @@ jobs:
           name: rito528-dotfiles
       - name: Check nixfmt formatting
         run: |
-          find . -name "*.nix" -not -path "./.git/*" -type f | \
-            xargs nix run nixpkgs#nixfmt -- --check
+          find . -name "*.nix" -not -path "./.git/*" -type f -print0 | \
+            xargs -0 nix run nixpkgs#nixfmt -- --check
       - run: nix flake check .


### PR DESCRIPTION
## 概要
- path filter で workflow 自体が skip されると required check と相性が悪いため、常時起動する `CI` workflow と `CI Gate` を追加しました。
- 既存の EditorConfig / Nix / Lint / Integration Test / Dev Shell は `workflow_call` 化し、`ci.yaml` から変更ファイルに応じて条件付きで呼び出す構成にしました。
- shellcheck / nixfmt 周辺の `find` / `xargs` を null 区切りにして、actionlint の指摘も解消しました。

## 確認事項
- 全 `.github/workflows/*.yaml` を Python の YAML parser で読み込み、構文として parse できることを確認しました。
- `nix run nixpkgs#actionlint` を実行し、GitHub Actions workflow と埋め込み shell script の lint が通ることを確認しました。
- ブランチプロテクションでは、個別 job ではなく `CI Gate` を required check にする想定です。

🤖 Generated with Codex
