### PR TITLE
ci: flake lock 更新を毎日実行する

### DIFF
--- a/.github/workflows/update-flake-lock.yaml
+++ b/.github/workflows/update-flake-lock.yaml
@@ -2,7 +2,7 @@ name: Update flake.lock
 
 on:
   schedule:
-    - cron: '0 0 * * 1'  # 毎週月曜日 UTC 0:00
+    - cron: '0 0 * * *'  # 毎日 UTC 0:00
   workflow_dispatch:
 
 jobs:
@@ -54,7 +54,7 @@ jobs:
 
           gh pr create \
             --title "deps: update flake.lock" \
-            --body "Weekly automated flake.lock updates for root flake and templates." \
+            --body "Daily automated flake.lock updates for root flake and templates." \
             --label "dependencies" \
             --base main \
             --head "$branch" 2>/dev/null || echo "PR already exists, branch updated"


### PR DESCRIPTION
## 概要
- flake.lock 更新 PR の自動作成を週次から日次に変更します。
- schedule の cron を毎日 UTC 0:00 実行にし、PR 本文の説明も Daily に合わせます。

## 確認事項
- PyYAML で workflow YAML がパースできることを確認しました。
- git diff --check で空白エラーがないことを確認しました。

## 補足
- 指定された nix-update-pr.yaml には schedule がなく pull_request 専用だったため、実際に週次 schedule を持つ update-flake-lock.yaml を変更しています。

🤖 Generated with Codex