### PR TITLE
fix: gemini-cli を antigravity-cli に移行する

### DIFF
--- a/modules/llm-agents.nix
+++ b/modules/llm-agents.nix
@@ -5,7 +5,7 @@
     pkgs.llm-agents.claude-code
     pkgs.llm-agents.copilot-cli
     pkgs.llm-agents.codex
-    pkgs.llm-agents.gemini-cli
+    pkgs.llm-agents.antigravity-cli
     pkgs.llm-agents.opencode
   ];
 }


### PR DESCRIPTION
## 概要
- `gemini-cli` が `antigravity-cli` にリネームされたため、`modules/llm-agents.nix` のパッケージ参照を更新した
- `pkgs.llm-agents.gemini-cli` → `pkgs.llm-agents.antigravity-cli` の1行変更

## 確認事項
- `home-manager build` はローカル環境の都合で未実施。GitHub Actions 側で確認予定
- `nixfmt` はクリーン（フォーマット差分なし）

🤖 Generated with Claude Code