### PR TITLE
takt を Home Manager 管理に追加

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -202,7 +202,8 @@
         "home-manager": "home-manager",
         "llm-agents": "llm-agents",
         "nixpkgs": "nixpkgs_2",
-        "nixvim": "nixvim"
+        "nixvim": "nixvim",
+        "takt": "takt"
       }
     },
     "systems": {
@@ -233,6 +234,26 @@
         "owner": "nix-systems",
         "ref": "future-26.11",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "takt": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782303278,
+        "narHash": "sha256-PJvgcn3O2EuqP+r5nQnmyPBTN6kmgKn6g3iQaOOPfe8=",
+        "owner": "nrslib",
+        "repo": "takt",
+        "rev": "d37cc398b55a5b4e4edee0ac8af503ce85de581a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nrslib",
+        "repo": "takt",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,10 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     llm-agents.url = "github:numtide/llm-agents.nix";
+    takt = {
+      url = "github:nrslib/takt";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
@@ -31,6 +35,7 @@
       home-manager,
       nixvim,
       llm-agents,
+      takt,
       ...
     }:
     let
@@ -56,7 +61,12 @@
             ./home.nix
           ];
           extraSpecialArgs = {
-            inherit username homeDirectory personal;
+            inherit
+              username
+              homeDirectory
+              personal
+              takt
+              ;
           };
         };
     in

--- a/home.nix
+++ b/home.nix
@@ -22,6 +22,7 @@
     ./modules/npm
     ./modules/actrun.nix
     ./modules/git-wt.nix
+    ./modules/takt.nix
   ];
 
   home.username = username;

--- a/modules/takt.nix
+++ b/modules/takt.nix
@@ -1,0 +1,4 @@
+{ pkgs, takt, ... }:
+{
+  home.packages = [ takt.packages.${pkgs.stdenv.hostPlatform.system}.default ];
+}


### PR DESCRIPTION
## 概要
- AI Agent ワークフロー用 CLI `takt` を Home Manager の `home.packages` で配備できるようにしました。
- `github:nrslib/takt` を flake input に追加し、既存の `nixpkgs` に follow させて lock 管理を単純にしています。
- 専用 module `modules/takt.nix` を追加し、`home.nix` から import する構成にしました。

## 確認事項
- `nixfmt flake.nix home.nix modules/takt.nix` を実行し、Nix ファイルのフォーマットを確認しました。
- `home-manager build --flake .#testuser` が成功し、Home Manager 構成として評価・ビルドできることを確認しました。
- `nix run github:nrslib/takt -- --version` が `0.48.0` を返し、takt CLI が実行できることを確認しました。

🤖 Generated with Codex