### PR TITLE
Renovate の actions 更新 PR 作成を安定待ち後にする

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,8 +19,7 @@
       "pinDigests": true,
       "minimumReleaseAge": "7 days",
       "minimumReleaseAgeBehaviour": "timestamp-required",
-      "internalChecksFilter": "none",
-      "prCreation": "immediate",
+      "internalChecksFilter": "strict",
       "rebaseWhen": "never",
       "automergeSchedule": [
         "on sunday"


### PR DESCRIPTION
## 概要
- GitHub Actions 更新で `minimumReleaseAge` 中の pending PR を先に作らないよう、actions 用 rule の `internalChecksFilter` を `strict` に変更
- `rebaseWhen: never` は維持し、digest 更新による rebase で stability-days が pending に戻り続ける問題を避ける
- `prCreation: immediate` を外し、Dependency Dashboard 側で安定待ち中の更新を扱う前提にする

## 確認事項
- `jq empty renovate.json` で JSON 構文が有効であることを確認
- `git diff --check` で whitespace error がないことを確認
- `npx --yes renovate --platform=local --dry-run=full` が終了コード 0 で完了し、Renovate が設定を読み込めることを確認
- Renovate dry-run では GitHub token 未設定による GitHub API rate limit 警告が出たが、設定読み込み自体は完了

🤖 Generated with Codex