### PR TITLE
python3 パッケージを追加

### DIFF
--- a/modules/packages.nix
+++ b/modules/packages.nix
@@ -18,5 +18,6 @@
     bubblewrap
     socat
     yazi
+    python3
   ];
 }


### PR DESCRIPTION
## 概要
- Codex が `python` コマンドを使おうとして毎回 `python3` にフォールバックする問題を解消するため、`python3` パッケージを `packages.nix` に追加
- nixpkgs の `python3` は `python` シンボリックリンクを含むため、追加するだけで `python` / `python3` 両方が使える

## 確認事項
- `home-manager build --flake .#testuser` でビルド成功を確認
- `nixfmt` でフォーマット済み

🤖 Generated with Claude Code