### PR TITLE
fix: llm-agents の overlay 参照名を shared-nixpkgs に修正

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -50,6 +50,7 @@
             "copilot.vim"
             "copilot-cli"
             "barbar.nvim"
+            "antigravity-cli"
           ];
       };
       mkHomeConfig =

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,7 @@
       system = "x86_64-linux";
       pkgs = import nixpkgs {
         inherit system;
-        overlays = [ llm-agents.overlays.default ];
+        overlays = [ llm-agents.overlays.shared-nixpkgs ];
         config.allowUnfreePredicate =
           pkg:
           builtins.elem (nixpkgs.lib.getName pkg) [


### PR DESCRIPTION
## 概要
- PR #470（`deps: update flake.lock`）の Integration Test / Nix Flake Check が失敗している問題を修正
- 原因1: `llm-agents.nix` の flake.lock 更新により、上流が blueprint ベースの `overlays.default` を廃止し `overlays.shared-nixpkgs` のみを公開するようになった。`flake.nix` の `overlays = [ llm-agents.overlays.default ];` を `overlays = [ llm-agents.overlays.shared-nixpkgs ];` に修正
- 原因2: `modules/llm-agents.nix` で使う `pkgs.llm-agents.antigravity-cli` が unfree ライセンスのパッケージで、`flake.nix` の `allowUnfreePredicate` に含まれておらず "Refusing to evaluate package" で失敗していた。`allowUnfreePredicate` のリストに `antigravity-cli` を追加

## 確認事項
- `nix flake check --no-build` で overlay 参照エラーが解消していることを確認（ただし `--no-build` は実ビルドをしないため unfree エラーは検出できなかった）
- `nix run home-manager/master -- build --flake .#testuser --no-out-link` を実行し、antigravity-cli を含むフルビルドが成功することを確認
- 上流 `numtide/llm-agents.nix` の新リビジョンの `flake.nix` / `packages/antigravity-cli/package.nix` を取得し、`overlays.shared-nixpkgs` のみが公開されていること、`antigravity-cli` の `meta.license` が `unfree` であることを確認
- PR #470 の CI ログで両方のエラーを再現確認済み

## 補足
- PR #470 は日次で force-push される bot 管理ブランチのため直接修正せず、本 PR で `main` を先に修正する
- 本 PR マージ後、PR #470 は次回の自動更新実行時（force-push）に修正済みの `flake.nix` を土台として再生成され green になる見込み。急ぐ場合は Update flake.lock ワークフローを手動実行（workflow_dispatch）する

🤖 Generated with Claude Code