### PR TITLE
fix: difit の fetchPnpmDeps を fetcherVersion 4 に更新

### DIFF
--- a/modules/npm/packages/difit.nix
+++ b/modules/npm/packages/difit.nix
@@ -11,8 +11,8 @@ let
   pnpmDeps = pkgs.fetchPnpmDeps {
     pname = "difit";
     inherit version src;
-    fetcherVersion = 3;
-    hash = "sha256-4gsCqgRI2KCMoTP8WCiOaTHOFnbIqC5js8Vk0/6lcWo=";
+    fetcherVersion = 4;
+    hash = "sha256-usFNABztdR24zn+CQ/w8CnpFpY7DQEDrNmNzmGhZgD4=";
   };
 in
 pkgs.stdenv.mkDerivation {


### PR DESCRIPTION
## 概要
- PR #472 (`update-flake-lock`) の nixpkgs bump 後、Integration Test が `fetchPnpmDeps` \`fetcherVersion = 3\` is no longer supported for \`pnpm_11\` で失敗していた原因を修正
- `modules/npm/packages/difit.nix` の `fetcherVersion` を非推奨の `3` から `4` に変更し、対応するハッシュを再計算した

## 確認事項
- 現行 nixpkgs pin でも `fetcherVersion` は 3/4 両方サポートされているが、PR #472 が bump する新しい nixpkgs では pnpm_11 系に対して `fetcherVersion = 3` の組み合わせが assert で禁止されていたことをエラーログとソース (`pkgs/build-support/node/fetch-pnpm-deps/default.nix`) から確認した
- `nix build` で difit パッケージ単体のビルドが成功することを確認した
- `nix build .#homeConfigurations.testuser.activationPackage` で home-manager 構成全体のビルドが成功することを確認した

## 補足
- 本 PR は #472 の nixpkgs bump がなくても現行 nixpkgs 上で成立する変更のため、#472 より先にマージしても問題ない

🤖 Generated with Claude Code