### PR TITLE
fix(renovate): digest 更新の automerge が strict internal check で止まる問題を修正

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,6 +35,7 @@
       ],
       "minimumReleaseAge": null,
       "minimumReleaseAgeBehaviour": "timestamp-optional",
+      "internalChecksFilter": "none",
       "automergeSchedule": [
         "on sunday"
       ]


### PR DESCRIPTION
## 概要
- PR #476 (`cachix/install-nix-action` digest 更新) が `automergeSchedule: on sunday` かつ日曜日でも automerge されない問題があった
- `renovate.json` の `packageRules` は action の digest/pinDigest 更新に2つのルールがマッチするが、後方ルールは `minimumReleaseAge` 系のみを上書きし、先頭ルールの `internalChecksFilter: "strict"` を引き継いでいた
- strict では Renovate 内部の merge confidence / stability チェックを通過するまで automerge が保留され、`cachix/install-nix-action` のようなマイナーな action ではこのチェックが揃わず pending のまま残っていたと考えられる
- digest/pinDigest 用ルールに `internalChecksFilter: "none"` を明示し、この保留を回避する

## 確認事項
- `jq . renovate.json` で JSON として妥当であることを確認した
- Renovate の実際のマージ挙動（dry-run 含む）はローカルから確認できないため未検証。次回の Renovate 実行後、PR #476 が Sunday の automerge で正しくマージされるかで実効性を確認する必要がある

## 補足
- ブランチ保護は未設定、merge 方式（merge/squash/rebase）もすべて許可済みであることを確認しており、これらは今回の事象の原因ではない

🤖 Generated with Claude Code