### PR TITLE
feat: flake.nix を multi-system 対応にする

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -23,3 +23,6 @@ jobs:
 
           - name: Run nix flake check
             run: nix flake check .
+
+          - name: Evaluate darwin home-manager config
+            run: nix eval .#homeConfigurations.testuser-darwin.config.home.username

--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,7 @@
             ];
         };
       mkHomeConfig =
-        system: username: homeDirectory: personal:
+        system: username: homeDirectory: identity:
         home-manager.lib.homeManagerConfiguration {
           pkgs = mkPkgs system;
           modules = [
@@ -66,7 +66,7 @@
             inherit
               username
               homeDirectory
-              personal
+              identity
               takt
               ;
           };
@@ -95,7 +95,7 @@
           system = "x86_64-linux";
           username = "rito528";
           homeDirectory = "/home/rito528";
-          personal = {
+          identity = {
             name = "rito528";
             email = "39003544+rito528@users.noreply.github.com";
             gpgKey = "F4022307254812F8";
@@ -105,7 +105,7 @@
           system = "x86_64-linux";
           username = "testuser";
           homeDirectory = "/home/testuser";
-          personal = {
+          identity = {
             name = "testuser";
             email = "testuser@example.com";
             gpgKey = "";
@@ -116,7 +116,7 @@
           system = "aarch64-darwin";
           username = "testuser";
           homeDirectory = "/Users/testuser";
-          personal = {
+          identity = {
             name = "testuser";
             email = "testuser@example.com";
             gpgKey = "";
@@ -127,7 +127,7 @@
     {
       packages.x86_64-linux = npmPackages;
       homeConfigurations = builtins.mapAttrs (
-        _: cfg: mkHomeConfig cfg.system cfg.username cfg.homeDirectory cfg.personal
+        _: cfg: mkHomeConfig cfg.system cfg.username cfg.homeDirectory cfg.identity
       ) machines;
       templates = {
         seichi-assist = {

--- a/flake.nix
+++ b/flake.nix
@@ -88,26 +88,47 @@
           }) nixFiles
         );
       npmPackages = loadPackagesDir ./modules/npm/packages (mkPkgs "x86_64-linux");
+
+      # 各マシン向け homeConfigurations の定義。新しいマシンを追加する場合はここにエントリを足す。
+      machines = {
+        rito528 = {
+          system = "x86_64-linux";
+          username = "rito528";
+          homeDirectory = "/home/rito528";
+          personal = {
+            name = "rito528";
+            email = "39003544+rito528@users.noreply.github.com";
+            gpgKey = "F4022307254812F8";
+          };
+        };
+        testuser = {
+          system = "x86_64-linux";
+          username = "testuser";
+          homeDirectory = "/home/testuser";
+          personal = {
+            name = "testuser";
+            email = "testuser@example.com";
+            gpgKey = "";
+          };
+        };
+        # aarch64-darwin 向け評価確認用。実 Mac 上の Unix ユーザー名は testuser のまま。
+        testuser-darwin = {
+          system = "aarch64-darwin";
+          username = "testuser";
+          homeDirectory = "/Users/testuser";
+          personal = {
+            name = "testuser";
+            email = "testuser@example.com";
+            gpgKey = "";
+          };
+        };
+      };
     in
     {
       packages.x86_64-linux = npmPackages;
-      homeConfigurations = {
-        "rito528" = mkHomeConfig "x86_64-linux" "rito528" "/home/rito528" {
-          name = "rito528";
-          email = "39003544+rito528@users.noreply.github.com";
-          gpgKey = "F4022307254812F8";
-        };
-        "testuser" = mkHomeConfig "x86_64-linux" "testuser" "/home/testuser" {
-          name = "testuser";
-          email = "testuser@example.com";
-          gpgKey = "";
-        };
-        "testuser-darwin" = mkHomeConfig "aarch64-darwin" "testuser" "/Users/testuser" {
-          name = "testuser";
-          email = "testuser@example.com";
-          gpgKey = "";
-        };
-      };
+      homeConfigurations = builtins.mapAttrs (
+        _: cfg: mkHomeConfig cfg.system cfg.username cfg.homeDirectory cfg.personal
+      ) machines;
       templates = {
         seichi-assist = {
           path = ./templates/seichi-assist;

--- a/flake.nix
+++ b/flake.nix
@@ -39,24 +39,25 @@
       ...
     }:
     let
-      system = "x86_64-linux";
-      pkgs = import nixpkgs {
-        inherit system;
-        overlays = [ llm-agents.overlays.shared-nixpkgs ];
-        config.allowUnfreePredicate =
-          pkg:
-          builtins.elem (nixpkgs.lib.getName pkg) [
-            "claude-code"
-            "copilot.vim"
-            "copilot-cli"
-            "barbar.nvim"
-            "antigravity-cli"
-          ];
-      };
+      mkPkgs =
+        system:
+        import nixpkgs {
+          inherit system;
+          overlays = [ llm-agents.overlays.shared-nixpkgs ];
+          config.allowUnfreePredicate =
+            pkg:
+            builtins.elem (nixpkgs.lib.getName pkg) [
+              "claude-code"
+              "copilot.vim"
+              "copilot-cli"
+              "barbar.nvim"
+              "antigravity-cli"
+            ];
+        };
       mkHomeConfig =
-        username: homeDirectory: personal:
+        system: username: homeDirectory: personal:
         home-manager.lib.homeManagerConfiguration {
-          inherit pkgs;
+          pkgs = mkPkgs system;
           modules = [
             nixvim.homeModules.nixvim
             ./home.nix
@@ -73,7 +74,7 @@
     in
     let
       loadPackagesDir =
-        dir:
+        dir: pkgs:
         let
           allFiles = builtins.readDir dir;
           nixFiles = builtins.filter (name: name != "default.nix" && builtins.match ".*\\.nix" name != null) (
@@ -86,17 +87,22 @@
             value = import (dir + "/${name}") { inherit pkgs; };
           }) nixFiles
         );
-      npmPackages = loadPackagesDir ./modules/npm/packages;
+      npmPackages = loadPackagesDir ./modules/npm/packages (mkPkgs "x86_64-linux");
     in
     {
-      packages.${system} = npmPackages;
+      packages.x86_64-linux = npmPackages;
       homeConfigurations = {
-        "rito528" = mkHomeConfig "rito528" "/home/rito528" {
+        "rito528" = mkHomeConfig "x86_64-linux" "rito528" "/home/rito528" {
           name = "rito528";
           email = "39003544+rito528@users.noreply.github.com";
           gpgKey = "F4022307254812F8";
         };
-        "testuser" = mkHomeConfig "testuser" "/home/testuser" {
+        "testuser" = mkHomeConfig "x86_64-linux" "testuser" "/home/testuser" {
+          name = "testuser";
+          email = "testuser@example.com";
+          gpgKey = "";
+        };
+        "testuser-darwin" = mkHomeConfig "aarch64-darwin" "testuser" "/Users/testuser" {
           name = "testuser";
           email = "testuser@example.com";
           gpgKey = "";

--- a/modules/git.nix
+++ b/modules/git.nix
@@ -1,12 +1,12 @@
-{ lib, personal, ... }:
+{ lib, identity, ... }:
 {
   programs.git = {
     enable = true;
     signing = {
       format = "openpgp";
     }
-    // lib.optionalAttrs (personal.gpgKey != "") {
-      key = personal.gpgKey;
+    // lib.optionalAttrs (identity.gpgKey != "") {
+      key = identity.gpgKey;
       signByDefault = true;
     };
     ignores = [
@@ -23,8 +23,8 @@
     ];
     settings = {
       user = {
-        name = personal.name;
-        email = personal.email;
+        name = identity.name;
+        email = identity.email;
       };
       gpg.program = "gpg";
       init.defaultBranch = "main";


### PR DESCRIPTION
## Summary
- macOS (Apple Silicon) 対応の第一弾。`system` 固定だった pkgs 生成と `mkHomeConfig` を system パラメータ化
- 評価確認用に `aarch64-darwin` 向け `homeConfigurations.testuser-darwin` を追加
- CI (`nix.yaml`) に darwin 側の eval チェックを追加し、Linux 専用な変更で aarch64-darwin 評価が壊れたことを Mac 実機なしで検知できるようにする

このPRの範囲は flake の骨格対応まで。`modules/actrun.nix` など Linux 専用パッケージの Darwin 対応、実ユーザー用 Mac エントリ、実機での `home-manager switch` 検証は後続PRで対応する。

## Test plan
- [x] `nix run nixpkgs#nixfmt -- --check flake.nix`
- [x] `nix flake check .`
- [x] `nix eval .#homeConfigurations.testuser-darwin.config.home.username` → `"testuser"`
- [x] `nix eval .#homeConfigurations.testuser.config.home.username` / `rito528` が引き続き評価できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)