### PR TITLE
feat: profile (personal/work) の配線基盤を追加する

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,11 @@
             ];
         };
       mkHomeConfig =
-        system: username: homeDirectory: identity:
+        system: username: homeDirectory: identity: profile:
+        assert builtins.elem profile [
+          "personal"
+          "work"
+        ];
         home-manager.lib.homeManagerConfiguration {
           pkgs = mkPkgs system;
           modules = [
@@ -67,6 +71,7 @@
               username
               homeDirectory
               identity
+              profile
               takt
               ;
           };
@@ -100,6 +105,7 @@
             email = "39003544+rito528@users.noreply.github.com";
             gpgKey = "F4022307254812F8";
           };
+          profile = "personal";
         };
         testuser = {
           system = "x86_64-linux";
@@ -110,6 +116,7 @@
             email = "testuser@example.com";
             gpgKey = "";
           };
+          profile = "personal";
         };
         # aarch64-darwin 向け評価確認用。実 Mac 上の Unix ユーザー名は testuser のまま。
         testuser-darwin = {
@@ -121,13 +128,26 @@
             email = "testuser@example.com";
             gpgKey = "";
           };
+          profile = "personal";
+        };
+        # profile 配線確認用。実マシンではない。
+        testuser-work = {
+          system = "x86_64-linux";
+          username = "testuser";
+          homeDirectory = "/home/testuser";
+          identity = {
+            name = "testuser";
+            email = "testuser@example.com";
+            gpgKey = "";
+          };
+          profile = "work";
         };
       };
     in
     {
       packages.x86_64-linux = npmPackages;
       homeConfigurations = builtins.mapAttrs (
-        _: cfg: mkHomeConfig cfg.system cfg.username cfg.homeDirectory cfg.identity
+        _: cfg: mkHomeConfig cfg.system cfg.username cfg.homeDirectory cfg.identity cfg.profile
       ) machines;
       templates = {
         seichi-assist = {


### PR DESCRIPTION
## Summary
- 業務用マシンでは入れてよいソフトウェアが private 機と異なりうるため、`machines` に `profile` (`"personal"` / `"work"`) を持たせ、`identity` と同様に `extraSpecialArgs` 経由で全モジュールから参照可能にする配線を追加
- 許容外の値 (typo など) は `mkHomeConfig` 内の `assert` で早期検知
- 配線確認用に `profile = "work"` の `testuser-work` エントリを追加（実マシンではない）

このPRはあくまで配線のみ。どのパッケージ・モジュールを work で外すかは業務要件次第の判断が必要なため、`modules/packages.nix` 等の実際の出し分けは次PRで対応する。

## Test plan
- [x] `nix run nixpkgs#nixfmt -- --check flake.nix`
- [x] `nix flake check .` → `testuser-work` が自動的に shallow evaluate されることを確認
- [x] `nix eval .#homeConfigurations.<name>._module.specialArgs.profile` で rito528/testuser/testuser-darwin が `"personal"`、testuser-work が `"work"` になることを確認
- [x] 既存の `config.home.username` 系 eval が壊れていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)