### PR TITLE
feat: nix-darwin 導入の土台を追加する

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -25,4 +25,4 @@ jobs:
             run: nix flake check .
 
           - name: Evaluate darwin home-manager config
-            run: nix eval .#homeConfigurations.testuser-darwin.config.home.username
+            run: nix eval .#darwinConfigurations.testuser-darwin.config.home-manager.users.testuser.home.username

--- a/flake.lock
+++ b/flake.lock
@@ -117,6 +117,27 @@
         "type": "github"
       }
     },
+    "nix-darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784500460,
+        "narHash": "sha256-UvORnAxTRHax7RG74W8Z2t4GvIkX6AjJ5kk0QlwZomo=",
+        "owner": "nix-darwin",
+        "repo": "nix-darwin",
+        "rev": "57a3171f94705599a2499248ca5758d5eb47c0e0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-darwin",
+        "ref": "master",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1784555310,
@@ -175,6 +196,7 @@
       "inputs": {
         "home-manager": "home-manager",
         "llm-agents": "llm-agents",
+        "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs_2",
         "nixvim": "nixvim",
         "takt": "takt"

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,10 @@
       url = "github:nix-community/nixvim";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    nix-darwin = {
+      url = "github:nix-darwin/nix-darwin/master";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     llm-agents.url = "github:numtide/llm-agents.nix";
     takt = {
       url = "github:nrslib/takt";
@@ -34,25 +38,28 @@
       nixpkgs,
       home-manager,
       nixvim,
+      nix-darwin,
       llm-agents,
       takt,
       ...
     }:
     let
+      nixpkgsOverlays = [ llm-agents.overlays.shared-nixpkgs ];
+      nixpkgsAllowUnfreePredicate =
+        pkg:
+        builtins.elem (nixpkgs.lib.getName pkg) [
+          "claude-code"
+          "copilot.vim"
+          "copilot-cli"
+          "barbar.nvim"
+          "antigravity-cli"
+        ];
       mkPkgs =
         system:
         import nixpkgs {
           inherit system;
-          overlays = [ llm-agents.overlays.shared-nixpkgs ];
-          config.allowUnfreePredicate =
-            pkg:
-            builtins.elem (nixpkgs.lib.getName pkg) [
-              "claude-code"
-              "copilot.vim"
-              "copilot-cli"
-              "barbar.nvim"
-              "antigravity-cli"
-            ];
+          overlays = nixpkgsOverlays;
+          config.allowUnfreePredicate = nixpkgsAllowUnfreePredicate;
         };
       mkHomeConfig =
         system: username: homeDirectory: identity: profile:
@@ -75,6 +82,47 @@
               takt
               ;
           };
+        };
+      mkDarwinConfig =
+        system: username: homeDirectory: identity: profile:
+        assert builtins.elem profile [
+          "personal"
+          "work"
+        ];
+        nix-darwin.lib.darwinSystem {
+          inherit system;
+          modules = [
+            {
+              nixpkgs.overlays = nixpkgsOverlays;
+              nixpkgs.config.allowUnfreePredicate = nixpkgsAllowUnfreePredicate;
+            }
+            ./modules/darwin
+            {
+              users.users.${username} = {
+                name = username;
+                home = homeDirectory;
+              };
+              system.primaryUser = username;
+            }
+            home-manager.darwinModules.home-manager
+            {
+              home-manager.extraSpecialArgs = {
+                inherit
+                  username
+                  homeDirectory
+                  identity
+                  profile
+                  takt
+                  ;
+              };
+              home-manager.users.${username} = {
+                imports = [
+                  nixvim.homeModules.nixvim
+                  ./home.nix
+                ];
+              };
+            }
+          ];
         };
     in
     let
@@ -118,18 +166,6 @@
           };
           profile = "personal";
         };
-        # aarch64-darwin 向け評価確認用。実 Mac 上の Unix ユーザー名は testuser のまま。
-        testuser-darwin = {
-          system = "aarch64-darwin";
-          username = "testuser";
-          homeDirectory = "/Users/testuser";
-          identity = {
-            name = "testuser";
-            email = "testuser@example.com";
-            gpgKey = "";
-          };
-          profile = "personal";
-        };
         # profile 配線確認用。実マシンではない。
         testuser-work = {
           system = "x86_64-linux";
@@ -143,12 +179,31 @@
           profile = "work";
         };
       };
+
+      # 各マシン向け darwinConfigurations の定義。実 Mac が判明したらここにエントリを足す。
+      darwinMachines = {
+        # aarch64-darwin 向け評価確認用。実マシンではない。
+        testuser-darwin = {
+          system = "aarch64-darwin";
+          username = "testuser";
+          homeDirectory = "/Users/testuser";
+          identity = {
+            name = "testuser";
+            email = "testuser@example.com";
+            gpgKey = "";
+          };
+          profile = "personal";
+        };
+      };
     in
     {
       packages.x86_64-linux = npmPackages;
       homeConfigurations = builtins.mapAttrs (
         _: cfg: mkHomeConfig cfg.system cfg.username cfg.homeDirectory cfg.identity cfg.profile
       ) machines;
+      darwinConfigurations = builtins.mapAttrs (
+        _: cfg: mkDarwinConfig cfg.system cfg.username cfg.homeDirectory cfg.identity cfg.profile
+      ) darwinMachines;
       templates = {
         seichi-assist = {
           path = ./templates/seichi-assist;

--- a/modules/darwin/default.nix
+++ b/modules/darwin/default.nix
@@ -1,0 +1,16 @@
+{ ... }:
+{
+  # nix-darwin の現行 stateVersion。
+  system.stateVersion = 6;
+
+  # Determinate Nix installer 等、nix-darwin の外で nix 自体を管理する場合は false のままにする。
+  nix.enable = false;
+
+  # まだ使わない。使う際は enable = true にして taps/brews/casks を追加する。
+  # cleanup を "zap"/"uninstall" にすると宣言外のものを削除してしまうため、
+  # 宣言していないものには触れないよう当面 "none" のままにする。
+  homebrew = {
+    enable = false;
+    onActivation.cleanup = "none";
+  };
+}


### PR DESCRIPTION
## Summary
- macOS 対応を home-manager 単独案から nix-darwin 導入案に変更（会社管理・プリインストール済みソフトウェアには手を出さず、宣言したものだけを管理する nix-darwin の性質を踏まえた判断）
- `nix-darwin` input を追加し、`mkHomeConfig` と同じ引数構成 (`system`/`username`/`homeDirectory`/`identity`/`profile`) の `mkDarwinConfig` を新設。`darwinSystem` + `home-manager.darwinModules.home-manager` を組み合わせ、既存の `home.nix`/`modules/*.nix` をそのまま Linux・macOS 共通のユーザー設定として再利用する
- `modules/darwin/default.nix` を新設（最小限）: `system.stateVersion`、`nix.enable = false`、`homebrew`（`enable = false`, `onActivation.cleanup = "none"`)
- 評価専用だった `homeConfigurations.testuser-darwin`（PR#490 で追加、home-manager 単独）を廃止し、`darwinConfigurations.testuser-darwin`（nix-darwin 経由）に一本化
- CI (`nix.yaml`) の darwin 評価ステップを `darwinConfigurations` 経由に更新

このPRは土台のみ。実際の業務 Mac の `darwinMachines` エントリ追加・Homebrew の有効化・taps/brews/casks の選定・システム設定の追加は行わない。

## 実機入手後にやること
1. `flake.nix` の `darwinMachines` に実エントリを追加する（`username`/`homeDirectory`/`identity`/`profile` を実機の値に書き換えるだけ）
2. 実機の nix インストール方法（Determinate installer など）を確認し、`modules/darwin/default.nix` の `nix.enable` をその方法に合わせて調整する
3. `darwin-rebuild switch --flake .#<name>` を実行し、実際にビルド・適用できることを確認する（今回のPRは評価レベルの確認までで、実ビルドは未検証）
4. ビルド時に `modules/actrun.nix` / `modules/git-wt.nix`（Linux バイナリ直指定）や `bubblewrap`（Linux 専用パッケージ）が失敗する可能性が高いので、Darwin 対応する
5. Homebrew を使う場合は `modules/darwin/default.nix` の `homebrew.enable = true` にし、taps/brews/casks を定義する（`onActivation.cleanup` は `"none"` のまま維持し、宣言外のソフトウェアを消さないようにする）
6. `profile = "work"` で実際に何を除外するかを決め、`modules/packages.nix` 等で出し分けを実装する

## Test plan
- [x] `nix run nixpkgs#nixfmt -- --check flake.nix modules/darwin/default.nix`
- [x] `nix flake check .`（既存 Linux 側が壊れていないこと）
- [x] `nix eval .#darwinConfigurations.testuser-darwin.config.home-manager.users.testuser.home.username` → `"testuser"`
- [x] `nix eval .#darwinConfigurations.testuser-darwin.config.system.primaryUser` → `"testuser"`
- [x] `nix eval .#darwinConfigurations.testuser-darwin.config.home-manager.users.testuser.programs.git.settings.user.email` → `identity` の配線を確認
- [x] `nix eval .#darwinConfigurations.testuser-darwin.config.homebrew.enable` → `false`
- ビルドは未実施（Linux ホストから aarch64-darwin の `system.build.toplevel` は実ビルドできないため評価レベルの確認に留めた。実機での `darwin-rebuild switch` は Mac 実機入手後に確認する）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
