### PR TITLE
docs-site のコード参照リンクを GitHub 絶対URLへ自動変換する

### DIFF
--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -14,3 +14,9 @@ mdbook serve docs-site --open
 
 - [`src/`](src/) 配下に Markdown ファイルを追加し、[`src/SUMMARY.md`](src/SUMMARY.md) にエントリを追加してください。
 - ビルド確認は `mdbook build docs-site` で行います。
+
+## コードへのリンクについて
+
+`src/*.md` からリポジトリ内のコードを参照するときは、`../../home.nix` のような相対パスで書いてください。
+[`preprocessors/github-links.sh`](preprocessors/github-links.sh) が mdBook のビルド時にこれらを検出し、GitHub 上の絶対 URL（`blob`/`tree`）へ自動的に書き換えます。
+デプロイ後のサイトはリポジトリのファイルツリーを持たないため、相対パスのままだと 404 になります。

--- a/docs-site/book.toml
+++ b/docs-site/book.toml
@@ -5,5 +5,8 @@ authors = ["rito528"]
 language = "ja"
 src = "src"
 
+[preprocessor.github-links]
+command = "./preprocessors/github-links.sh"
+
 [output.html]
 git-repository-url = "https://github.com/rito528/dotfiles"

--- a/docs-site/preprocessors/github-links.sh
+++ b/docs-site/preprocessors/github-links.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "supports" ]]; then
+  exit 0
+fi
+
+repo_url="https://github.com/rito528/dotfiles"
+
+jq --arg repo "$repo_url" '
+  def normalize_path:
+    split("/")
+    | reduce .[] as $seg ([];
+        if ($seg == "" or $seg == ".") then .
+        elif $seg == ".." then (if length > 0 then .[:-1] else . end)
+        else . + [$seg] end)
+    | join("/");
+
+  def fix_content($chapter_path):
+    ($chapter_path | if test("/") then sub("/[^/]*$"; "") else "" end) as $reldir
+    | (if $reldir == "" then "docs-site/src" else "docs-site/src/" + $reldir end) as $basedir
+    | gsub(
+        "\\]\\((?<target>\\.\\./[^)]+)\\)";
+        ($basedir + "/" + .target | normalize_path) as $abs
+        | (if (.target | endswith("/")) then "tree" else "blob" end) as $kind
+        | "](" + $repo + "/" + $kind + "/main/" + $abs + ")"
+      );
+
+  def walk_item:
+    if (type == "object") and has("Chapter") then
+      (.Chapter.path) as $p
+      | (if $p != null then .Chapter.content |= fix_content($p) else . end)
+      | .Chapter.sub_items |= map(walk_item)
+    else . end;
+
+  (.[1].items |= map(walk_item)) | .[1]
+'


### PR DESCRIPTION
## 概要
- GitHub Pages にデプロイした mdBook サイトはリポジトリのファイルツリーを持たないため、`src/*.md` 内の相対リンク（`../../home.nix` 等）がそのまま公開サイトでは 404 になっていた
- mdBook の preprocessor (`docs-site/preprocessors/github-links.sh`) を追加し、ビルド時にのみ `../` で始まる相対リンクを GitHub の `blob`/`tree` 絶対 URL へ書き換える
- ソース側 (`docs-site/src/*.md`) は従来どおり相対パスのまま維持できる

## 確認事項
- `nix shell nixpkgs#mdbook nixpkgs#jq --command mdbook build docs-site` を実際に実行し、preprocessor が正常終了して `docs-site/book/*.html` にリンクが書き換わることを確認済み（生成された blob/tree URL が実際にリポジトリ内に存在するパスであることも突き合わせ確認済み）
- 実装時、mdBook の preprocessor 入出力 JSON の実際のフィールド名（`items`。想定していた `sections` ではなかった）を実ビルドで検証し、スクリプトを修正した
- ネストしたディレクトリの章がある場合の相対パス解決や、ディレクトリリンク（末尾 `/`）を `tree`、ファイルリンクを `blob` にする分岐もサンプル JSON で検証済み
- `shellcheck` を通過済み
- CI ワークフロー (`docs.yaml`, `deploy-docs.yaml`) は `nix shell nixpkgs#mdbook --command ...` を使っており、`jq` はランナー標準ツールとして利用可能なため変更していない

## 補足
- レビュー中に `.github/workflows/docs.yaml` / `deploy-docs.yaml` の既存の `- parallel:` step が actionlint で無効な構文と判定されることに気づいたが、本 PR の変更とは無関係の既存事象のため、この PR では手を加えていない

🤖 Generated with Claude Code