### PR TITLE
fix(renovate): actions の PR が automerge されない原因の rebaseWhen を修正する

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,7 +20,7 @@
       "minimumReleaseAge": "7 days",
       "minimumReleaseAgeBehaviour": "timestamp-required",
       "internalChecksFilter": "strict",
-      "rebaseWhen": "never",
+      "rebaseWhen": "conflicted",
       "automergeSchedule": [
         "on sunday"
       ]


### PR DESCRIPTION
## 概要
- action 系の依存更新 PR が `automergeSchedule: ["on sunday"]` を設定しているにもかかわらず、日曜になっても自動マージされない問題を修正する
- 原因は `rebaseWhen: "never"`。Renovate は既存ブランチがある状態で `rebaseWhen === "never"` を検出すると、[`processBranch` を `no-work` で早期 return する](https://github.com/renovatebot/renovate/blob/main/lib/workers/repository/update/branch/index.ts#L566-L577)。automerge を判定する `checkAutoMerge` はその後段にあるため、`automergeSchedule` は評価されず、曜日に関係なく自動マージされない状態だった
- 早期 return の条件は `rebaseWhen === "never"` のみなので `conflicted` に変更する。base ブランチが進んだだけでは rebase しない挙動は保たれるため、force push で `minimumReleaseAge` の判定がやり直しになる問題 (c8bde1c) も再発しない

## 確認事項
- `rebaseWhen: "never"` が入った c8bde1c (2026-04-19) 以降、action 系 PR (#476, #466, #418, #399, #395, #362, #361) はすべて手動マージで、`app/renovate` による自動マージは 1 件もない。一方 `rebaseWhen` を上書きしていない customManager 系 (difit, git-wt, ccusage, mcp-grafana) は数時間以内に自動マージされており、7/19(日) も #482 が 21:35 JST に自動マージ済み。Renovate 自体は日曜も動いていることを確認した
- 現在 open の #485 は `mergeStateStatus: CLEAN` かつ全チェック SUCCESS で、automerge を阻む要素が他にないことを確認した
- スケジュール文字列 `on sunday` は later の `on → dayOfWeek` として正しくパースされ、Renovate 本体のテストでも同形式 (`on friday and saturday`) が日中に true になることを確認した。スケジュール記述自体に問題はない
- `renovate.json` の 1 行変更のため、実際の検証は CI の Renovate Config Check に委ねる

## 補足
- 効果が確認できるのは次の日曜。それまでに #485 をマージしたい場合は、PR 本文の rebase チェックボックスを入れると `dependencyDashboardCheck` が立って早期 return を回避できる
- 7/19 の `internalChecksFilter: "none"` 追加 (3c1a1a9) は 21:36 JST にマージされ、その 1 分前が最後の Renovate 実行だったため効果が検証されていない。修正内容自体は妥当だが、automerge されない真因はこちらだった

🤖 Generated with Claude Code