### PR TITLE
feat: VSCode を Homebrew cask で導入する

### DIFF
--- a/modules/darwin/default.nix
+++ b/modules/darwin/default.nix
@@ -16,6 +16,8 @@
       "karabiner-elements"
       # 仮想化・GUI 権限が必要なため cask で導入する(旧名 "docker")。
       "docker-desktop"
+      # 拡張機能の管理と自動更新を VSCode 自身に任せたいため cask で導入する。
+      "visual-studio-code"
     ];
   };
 }


### PR DESCRIPTION
## 概要
- macOS 環境で VSCode を Homebrew cask 管理下に入れ、`darwin-rebuild switch` で導入されるようにした
- nix パッケージではなく cask を選んだ理由は、拡張機能の管理と自動更新を VSCode 自身に任せたいため
- 影響範囲は `modules/darwin/default.nix` の `homebrew.casks` のみで、Linux 側には影響しない

## 確認事項
- `nixfmt` を適用し、フォーマット差分が出ないことを確認
- `nix eval .#darwinConfigurations.testuser-darwin.config.homebrew.casks` が成功し、`visual-studio-code` が cask 一覧に含まれることを確認
- 実機での `darwin-rebuild switch` は未実施。cask 名が Homebrew 公式の `visual-studio-code` である点をレビューで確認してほしい
- home-manager には影響しない変更のため `home-manager build` は実施していない

## 補足
- `onActivation.cleanup = "none"` のままなので、すでに手動で VSCode を入れている環境でも既存のインストールが壊されることはない

🤖 Generated with Claude Code