### PR TITLE
feat: HHKB JP を PC モードで使う際に かな/変換/無変換 で IME を切り替えられるようにする

### DIFF
--- a/config/karabiner/windows-style.json
+++ b/config/karabiner/windows-style.json
@@ -192,6 +192,35 @@
       ]
     },
     {
+      "description": "Japanese IME keys for JIS keyboards in PC mode (Kana/Henkan -> IME on, Muhenkan -> IME off)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "japanese_pc_katakana",
+            "modifiers": { "mandatory": [], "optional": ["any"] }
+          },
+          "to": [ { "key_code": "japanese_kana" } ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "japanese_pc_xfer",
+            "modifiers": { "mandatory": [], "optional": ["any"] }
+          },
+          "to": [ { "key_code": "japanese_kana" } ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "japanese_pc_nfer",
+            "modifiers": { "mandatory": [], "optional": ["any"] }
+          },
+          "to": [ { "key_code": "japanese_eisuu" } ]
+        }
+      ]
+    },
+    {
       "description": "Caps Lock to Control (real Control key for CLI/readline/vim/tmux use)",
       "manipulators": [
         {


### PR DESCRIPTION
## 概要
- HHKB JP を PC (Windows) モードで使っていると、かなキーは macOS が IME 切り替えとして解釈する `japanese_kana` ではなく `japanese_pc_katakana` を送るため、IME ON に使えなかった
- [`config/karabiner/windows-style.json`](config/karabiner/windows-style.json) に PC 用キーコードを macOS の IME キーへ変換するルールを追加した（かな・変換 → IME ON、無変換 → IME OFF）
- 影響範囲は Karabiner の Complex Modifications 候補ルールのみ。既存 3 ルールには手を入れていない

## 確認事項
- Karabiner-EventViewer で実機の HHKB を確認し、かな = `japanese_pc_katakana`、スペース右横 = `japanese_pc_xfer`、その右 = `japanese_pc_nfer` を送っていることを確認した
- `karabiner.json` に `simple_modifications` や競合するルールがないこと、入力ソースが ABC と 日本語 - ローマ字 の 2 つで `japanese_kana` が届けば IME ON になる構成であることを確認した
- `jq` で JSON の妥当性を確認し、`nix eval` で darwin 構成が参照する store path に新ルールが含まれることを確認した
- `home-manager build --flake .#testuser` は testuser が x86_64-linux 前提のため darwin 実機では platform mismatch となり完走しない。代わりに `darwinConfigurations.testuser-darwin` の eval で検証した
- 実際の IME 切り替え動作は未確認。`darwin-rebuild switch` と Karabiner GUI でのルール有効化が前提になるため

## 補足
- `karabiner.json` は Karabiner がルールを実体コピーする状態ファイルで Nix 管理外のため、適用には GUI での一度きりの有効化操作が必要
- 変換・無変換 のマッピングは Windows の慣習に合わせた追加分。macOS では現状どちらも無反応なキーなので失う操作はない

🤖 Generated with Claude Code