### PR TITLE
feat: Karabiner-Elements でスクリーンショットと画面ロックのショートカットキーを置き換える

### DIFF
--- a/config/karabiner/windows-style.json
+++ b/config/karabiner/windows-style.json
@@ -131,6 +131,14 @@
         },
         {
           "type": "basic",
+          "from": {
+            "key_code": "l",
+            "modifiers": { "mandatory": ["command"], "optional": [] }
+          },
+          "to": [ { "key_code": "q", "modifiers": ["left_command", "left_control"] } ]
+        },
+        {
+          "type": "basic",
           "from": { "key_code": "c", "modifiers": { "mandatory": ["control"], "optional": [] } },
           "to": [ { "key_code": "c", "modifiers": ["left_command"] } ]
         },
@@ -204,6 +212,11 @@
             "modifiers": { "mandatory": ["control", "shift"], "optional": [] }
           },
           "to": [ { "key_code": "s", "modifiers": ["left_command", "left_shift"] } ]
+        },
+        {
+          "type": "basic",
+          "from": { "key_code": "l", "modifiers": { "mandatory": ["control"], "optional": [] } },
+          "to": [ { "key_code": "l", "modifiers": ["left_command"] } ]
         }
       ]
     },

--- a/config/karabiner/windows-style.json
+++ b/config/karabiner/windows-style.json
@@ -123,6 +123,14 @@
       "manipulators": [
         {
           "type": "basic",
+          "from": {
+            "key_code": "s",
+            "modifiers": { "mandatory": ["command", "shift"], "optional": [] }
+          },
+          "to": [ { "key_code": "4", "modifiers": ["left_command", "left_shift"] } ]
+        },
+        {
+          "type": "basic",
           "from": { "key_code": "c", "modifiers": { "mandatory": ["control"], "optional": [] } },
           "to": [ { "key_code": "c", "modifiers": ["left_command"] } ]
         },
@@ -188,6 +196,14 @@
           "type": "basic",
           "from": { "key_code": "w", "modifiers": { "mandatory": ["control"], "optional": [] } },
           "to": [ { "key_code": "w", "modifiers": ["left_command"] } ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "s",
+            "modifiers": { "mandatory": ["control", "shift"], "optional": [] }
+          },
+          "to": [ { "key_code": "s", "modifiers": ["left_command", "left_shift"] } ]
         }
       ]
     },


### PR DESCRIPTION
## 概要

Windows 寄りのキーバインドで不足していた「スクリーンショット」と「画面ロック」を、Windows と同じ打鍵で使えるようにする。

| 押すキー（印字） | 変更後の動作 |
| --- | --- |
| Win + Shift + S | 範囲選択スクリーンショット (Cmd+Shift+4) |
| Win + L | ロック画面 (Cmd+Ctrl+Q) |
| Ctrl + Shift + S | 別名で保存 (Cmd+Shift+S) |
| Ctrl + L | アドレスバー / 行選択 (Cmd+L) |

## 変更内容

### 1. スクリーンショット (Win + Shift + S)

PC キーボードの Win キーは macOS 既定で Command を送るため、`Cmd+Shift+S` を `Cmd+Shift+4` に置き換える。

奪われる `Cmd+Shift+S`（別名で保存 / 複製）は、これまで未定義で macOS では何も起きなかった `Ctrl+Shift+S` に退避する。Windows の別名保存も Ctrl+Shift+S なので打鍵は一致する。

### 2. 画面ロック (Win + L)

`Cmd+L` を macOS のロック画面 `Cmd+Ctrl+Q` に置き換える。

奪われる `Cmd+L`（ブラウザのアドレスバー、エディタの行選択）は `Ctrl+L` に退避する。Windows 側でもアドレスバーは Ctrl+L、VS Code の行選択も Ctrl+L なので打鍵は一致する。

## 実装上の注意

Karabiner はマニピュレータを上から順に適用し、あるマニピュレータの出力はそれより**後ろ**のマニピュレータにのみ渡る。そのため Cmd 起点のルール（スクショ・ロック）は Ctrl→Cmd 変換群より**前**に配置している。

逆順にすると `Ctrl+L → Cmd+L` の出力がロックのルールに拾われ、アドレスバーを開こうとしただけで画面がロックされる。

Caps Lock → Control のルールはファイル末尾にあり Ctrl→Cmd 変換より後ろで評価されるため、Caps Lock は本物の Control のまま（CLI / vim / tmux 用途）で今回の変更の影響を受けない。

## 動作確認

- `jq` による JSON 妥当性チェックと適用順の確認
- `modules/karabiner.nix` は darwin 限定のため、Linux 側の `home-manager build` では評価対象外

反映には `home-manager switch` 後、Karabiner-Elements の Complex Modifications で該当ルールの再有効化が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
