### PR TITLE
feat: nix develop に入る ns エイリアスを追加する

### DIFF
--- a/modules/shell.nix
+++ b/modules/shell.nix
@@ -29,6 +29,7 @@
       alert = ''notify-send --urgency=low -i "$([ $? = 0 ] && echo terminal || echo error)" "$(history|tail -n1|sed -e 's/^\s*[0-9]\+\s*//;s/[;&|]\s*alert$//')"'';
       delete-branches = "git fetch -p && git branch --merged | grep -v '*' | xargs -r git branch -d";
       gpull = "git switch $(git symbolic-ref refs/remotes/origin/HEAD | sed 's|refs/remotes/origin/||') && git pull";
+      ns = "nix develop -c $SHELL";
     };
 
     plugins = [


### PR DESCRIPTION
## 概要

direnv が使えない環境で dev shell に入るための `ns` エイリアスを追加する。

```nix
ns = "nix develop -c $SHELL";
```

シングルクォートで zshrc に生成されるため、`$SHELL` は実行時に展開される。

## 検証

- `nixfmt` 適用済み
- `home-manager build --flake .#testuser` 成功
- 生成物に `alias -- ns='nix develop -c $SHELL'` を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)