### PR TITLE
fix: Karabiner の Windows 風キーマップをターミナル除外の Ctrl/Cmd 入れ替えに置き換える

### DIFF
--- a/config/karabiner/windows-style.json
+++ b/config/karabiner/windows-style.json
@@ -2,125 +2,16 @@
   "title": "Windows-style navigation and shortcuts (for PC keyboards used in Windows mode)",
   "rules": [
     {
-      "description": "Windows-style word/line/document navigation and selection",
+      "description": "Windows keys with no macOS equivalent (Win+L lock / Win+Shift+S screenshot / Alt+Tab). Always on, including terminals.",
       "manipulators": [
         {
           "type": "basic",
           "from": {
-            "key_code": "left_arrow",
-            "modifiers": { "mandatory": ["control"], "optional": [] }
+            "key_code": "l",
+            "modifiers": { "mandatory": ["command"], "optional": [] }
           },
-          "to": [ { "key_code": "left_arrow", "modifiers": ["left_option"] } ]
+          "to": [ { "key_code": "q", "modifiers": ["left_command", "left_control"] } ]
         },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "right_arrow",
-            "modifiers": { "mandatory": ["control"], "optional": [] }
-          },
-          "to": [ { "key_code": "right_arrow", "modifiers": ["left_option"] } ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "left_arrow",
-            "modifiers": { "mandatory": ["control", "shift"], "optional": [] }
-          },
-          "to": [ { "key_code": "left_arrow", "modifiers": ["left_option", "left_shift"] } ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "right_arrow",
-            "modifiers": { "mandatory": ["control", "shift"], "optional": [] }
-          },
-          "to": [ { "key_code": "right_arrow", "modifiers": ["left_option", "left_shift"] } ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "delete_or_backspace",
-            "modifiers": { "mandatory": ["control"], "optional": [] }
-          },
-          "to": [ { "key_code": "delete_or_backspace", "modifiers": ["left_option"] } ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "delete_forward",
-            "modifiers": { "mandatory": ["control"], "optional": [] }
-          },
-          "to": [ { "key_code": "delete_forward", "modifiers": ["left_option"] } ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "home",
-            "modifiers": { "mandatory": [], "optional": [] }
-          },
-          "to": [ { "key_code": "left_arrow", "modifiers": ["left_command"] } ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "end",
-            "modifiers": { "mandatory": [], "optional": [] }
-          },
-          "to": [ { "key_code": "right_arrow", "modifiers": ["left_command"] } ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "home",
-            "modifiers": { "mandatory": ["shift"], "optional": [] }
-          },
-          "to": [ { "key_code": "left_arrow", "modifiers": ["left_command", "left_shift"] } ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "end",
-            "modifiers": { "mandatory": ["shift"], "optional": [] }
-          },
-          "to": [ { "key_code": "right_arrow", "modifiers": ["left_command", "left_shift"] } ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "home",
-            "modifiers": { "mandatory": ["control"], "optional": [] }
-          },
-          "to": [ { "key_code": "up_arrow", "modifiers": ["left_command"] } ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "end",
-            "modifiers": { "mandatory": ["control"], "optional": [] }
-          },
-          "to": [ { "key_code": "down_arrow", "modifiers": ["left_command"] } ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "home",
-            "modifiers": { "mandatory": ["control", "shift"], "optional": [] }
-          },
-          "to": [ { "key_code": "up_arrow", "modifiers": ["left_command", "left_shift"] } ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "end",
-            "modifiers": { "mandatory": ["control", "shift"], "optional": [] }
-          },
-          "to": [ { "key_code": "down_arrow", "modifiers": ["left_command", "left_shift"] } ]
-        }
-      ]
-    },
-    {
-      "description": "Windows-style shortcuts (Ctrl -> Cmd for copy/paste/save/etc.)",
-      "manipulators": [
         {
           "type": "basic",
           "from": {
@@ -132,91 +23,373 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "l",
-            "modifiers": { "mandatory": ["command"], "optional": [] }
+            "key_code": "tab",
+            "modifiers": { "mandatory": ["option"], "optional": ["any"] }
           },
-          "to": [ { "key_code": "q", "modifiers": ["left_command", "left_control"] } ]
-        },
+          "to": [ { "key_code": "tab", "modifiers": ["left_command"] } ]
+        }
+      ]
+    },
+    {
+      "description": "Fixes that must stay above the Ctrl/Cmd swap: keep Ctrl+Tab as tab cycling, and map Ctrl+Y to redo. Skipped in terminals.",
+      "manipulators": [
         {
           "type": "basic",
-          "from": { "key_code": "c", "modifiers": { "mandatory": ["control"], "optional": [] } },
-          "to": [ { "key_code": "c", "modifiers": ["left_command"] } ]
-        },
-        {
-          "type": "basic",
-          "from": { "key_code": "v", "modifiers": { "mandatory": ["control"], "optional": [] } },
-          "to": [ { "key_code": "v", "modifiers": ["left_command"] } ]
-        },
-        {
-          "type": "basic",
-          "from": { "key_code": "x", "modifiers": { "mandatory": ["control"], "optional": [] } },
-          "to": [ { "key_code": "x", "modifiers": ["left_command"] } ]
-        },
-        {
-          "type": "basic",
-          "from": { "key_code": "z", "modifiers": { "mandatory": ["control"], "optional": [] } },
-          "to": [ { "key_code": "z", "modifiers": ["left_command"] } ]
-        },
-        {
-          "type": "basic",
-          "from": { "key_code": "y", "modifiers": { "mandatory": ["control"], "optional": [] } },
-          "to": [ { "key_code": "z", "modifiers": ["left_command", "left_shift"] } ]
-        },
-        {
-          "type": "basic",
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "^com\\.mitchellh\\.ghostty$",
+                "^com\\.apple\\.Terminal$",
+                "^com\\.googlecode\\.iterm2$"
+              ]
+            }
+          ],
           "from": {
-            "key_code": "z",
+            "key_code": "tab",
+            "modifiers": { "mandatory": ["control"], "optional": ["shift"] }
+          },
+          "to": [ { "key_code": "tab", "modifiers": ["left_control"] } ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "^com\\.mitchellh\\.ghostty$",
+                "^com\\.apple\\.Terminal$",
+                "^com\\.googlecode\\.iterm2$"
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "y",
+            "modifiers": { "mandatory": ["control"], "optional": [] }
+          },
+          "to": [ { "key_code": "z", "modifiers": ["left_command", "left_shift"] } ]
+        }
+      ]
+    },
+    {
+      "description": "Windows-style word/line/document navigation and selection. Skipped in terminals (Home/End and Ctrl+arrow are handled by the shell).",
+      "manipulators": [
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "^com\\.mitchellh\\.ghostty$",
+                "^com\\.apple\\.Terminal$",
+                "^com\\.googlecode\\.iterm2$"
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "left_arrow",
+            "modifiers": { "mandatory": ["control"], "optional": [] }
+          },
+          "to": [ { "key_code": "left_arrow", "modifiers": ["left_option"] } ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "^com\\.mitchellh\\.ghostty$",
+                "^com\\.apple\\.Terminal$",
+                "^com\\.googlecode\\.iterm2$"
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "right_arrow",
+            "modifiers": { "mandatory": ["control"], "optional": [] }
+          },
+          "to": [ { "key_code": "right_arrow", "modifiers": ["left_option"] } ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "^com\\.mitchellh\\.ghostty$",
+                "^com\\.apple\\.Terminal$",
+                "^com\\.googlecode\\.iterm2$"
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "left_arrow",
             "modifiers": { "mandatory": ["control", "shift"], "optional": [] }
           },
-          "to": [ { "key_code": "z", "modifiers": ["left_command", "left_shift"] } ]
+          "to": [ { "key_code": "left_arrow", "modifiers": ["left_option", "left_shift"] } ]
         },
         {
           "type": "basic",
-          "from": { "key_code": "a", "modifiers": { "mandatory": ["control"], "optional": [] } },
-          "to": [ { "key_code": "a", "modifiers": ["left_command"] } ]
-        },
-        {
-          "type": "basic",
-          "from": { "key_code": "s", "modifiers": { "mandatory": ["control"], "optional": [] } },
-          "to": [ { "key_code": "s", "modifiers": ["left_command"] } ]
-        },
-        {
-          "type": "basic",
-          "from": { "key_code": "f", "modifiers": { "mandatory": ["control"], "optional": [] } },
-          "to": [ { "key_code": "f", "modifiers": ["left_command"] } ]
-        },
-        {
-          "type": "basic",
-          "from": { "key_code": "p", "modifiers": { "mandatory": ["control"], "optional": [] } },
-          "to": [ { "key_code": "p", "modifiers": ["left_command"] } ]
-        },
-        {
-          "type": "basic",
-          "from": { "key_code": "t", "modifiers": { "mandatory": ["control"], "optional": [] } },
-          "to": [ { "key_code": "t", "modifiers": ["left_command"] } ]
-        },
-        {
-          "type": "basic",
-          "from": { "key_code": "n", "modifiers": { "mandatory": ["control"], "optional": [] } },
-          "to": [ { "key_code": "n", "modifiers": ["left_command"] } ]
-        },
-        {
-          "type": "basic",
-          "from": { "key_code": "w", "modifiers": { "mandatory": ["control"], "optional": [] } },
-          "to": [ { "key_code": "w", "modifiers": ["left_command"] } ]
-        },
-        {
-          "type": "basic",
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "^com\\.mitchellh\\.ghostty$",
+                "^com\\.apple\\.Terminal$",
+                "^com\\.googlecode\\.iterm2$"
+              ]
+            }
+          ],
           "from": {
-            "key_code": "s",
+            "key_code": "right_arrow",
             "modifiers": { "mandatory": ["control", "shift"], "optional": [] }
           },
-          "to": [ { "key_code": "s", "modifiers": ["left_command", "left_shift"] } ]
+          "to": [ { "key_code": "right_arrow", "modifiers": ["left_option", "left_shift"] } ]
         },
         {
           "type": "basic",
-          "from": { "key_code": "l", "modifiers": { "mandatory": ["control"], "optional": [] } },
-          "to": [ { "key_code": "l", "modifiers": ["left_command"] } ]
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "^com\\.mitchellh\\.ghostty$",
+                "^com\\.apple\\.Terminal$",
+                "^com\\.googlecode\\.iterm2$"
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "delete_or_backspace",
+            "modifiers": { "mandatory": ["control"], "optional": [] }
+          },
+          "to": [ { "key_code": "delete_or_backspace", "modifiers": ["left_option"] } ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "^com\\.mitchellh\\.ghostty$",
+                "^com\\.apple\\.Terminal$",
+                "^com\\.googlecode\\.iterm2$"
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "delete_forward",
+            "modifiers": { "mandatory": ["control"], "optional": [] }
+          },
+          "to": [ { "key_code": "delete_forward", "modifiers": ["left_option"] } ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "^com\\.mitchellh\\.ghostty$",
+                "^com\\.apple\\.Terminal$",
+                "^com\\.googlecode\\.iterm2$"
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "home",
+            "modifiers": { "mandatory": [], "optional": [] }
+          },
+          "to": [ { "key_code": "left_arrow", "modifiers": ["left_command"] } ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "^com\\.mitchellh\\.ghostty$",
+                "^com\\.apple\\.Terminal$",
+                "^com\\.googlecode\\.iterm2$"
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "end",
+            "modifiers": { "mandatory": [], "optional": [] }
+          },
+          "to": [ { "key_code": "right_arrow", "modifiers": ["left_command"] } ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "^com\\.mitchellh\\.ghostty$",
+                "^com\\.apple\\.Terminal$",
+                "^com\\.googlecode\\.iterm2$"
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "home",
+            "modifiers": { "mandatory": ["shift"], "optional": [] }
+          },
+          "to": [ { "key_code": "left_arrow", "modifiers": ["left_command", "left_shift"] } ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "^com\\.mitchellh\\.ghostty$",
+                "^com\\.apple\\.Terminal$",
+                "^com\\.googlecode\\.iterm2$"
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "end",
+            "modifiers": { "mandatory": ["shift"], "optional": [] }
+          },
+          "to": [ { "key_code": "right_arrow", "modifiers": ["left_command", "left_shift"] } ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "^com\\.mitchellh\\.ghostty$",
+                "^com\\.apple\\.Terminal$",
+                "^com\\.googlecode\\.iterm2$"
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "home",
+            "modifiers": { "mandatory": ["control"], "optional": [] }
+          },
+          "to": [ { "key_code": "up_arrow", "modifiers": ["left_command"] } ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "^com\\.mitchellh\\.ghostty$",
+                "^com\\.apple\\.Terminal$",
+                "^com\\.googlecode\\.iterm2$"
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "end",
+            "modifiers": { "mandatory": ["control"], "optional": [] }
+          },
+          "to": [ { "key_code": "down_arrow", "modifiers": ["left_command"] } ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "^com\\.mitchellh\\.ghostty$",
+                "^com\\.apple\\.Terminal$",
+                "^com\\.googlecode\\.iterm2$"
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "home",
+            "modifiers": { "mandatory": ["control", "shift"], "optional": [] }
+          },
+          "to": [ { "key_code": "up_arrow", "modifiers": ["left_command", "left_shift"] } ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "^com\\.mitchellh\\.ghostty$",
+                "^com\\.apple\\.Terminal$",
+                "^com\\.googlecode\\.iterm2$"
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "end",
+            "modifiers": { "mandatory": ["control", "shift"], "optional": [] }
+          },
+          "to": [ { "key_code": "down_arrow", "modifiers": ["left_command", "left_shift"] } ]
+        }
+      ]
+    },
+    {
+      "description": "Swap Ctrl and Cmd so every Windows shortcut works at once (Ctrl+C/V/Z, Ctrl+Shift+P, Ctrl+B, Ctrl+R, Ctrl+/-, ...). Skipped in terminals so Ctrl+C stays SIGINT.",
+      "manipulators": [
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "^com\\.mitchellh\\.ghostty$",
+                "^com\\.apple\\.Terminal$",
+                "^com\\.googlecode\\.iterm2$"
+              ]
+            }
+          ],
+          "from": { "key_code": "left_control", "modifiers": { "optional": ["any"] } },
+          "to": [ { "key_code": "left_command" } ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "^com\\.mitchellh\\.ghostty$",
+                "^com\\.apple\\.Terminal$",
+                "^com\\.googlecode\\.iterm2$"
+              ]
+            }
+          ],
+          "from": { "key_code": "left_command", "modifiers": { "optional": ["any"] } },
+          "to": [ { "key_code": "left_control" } ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "^com\\.mitchellh\\.ghostty$",
+                "^com\\.apple\\.Terminal$",
+                "^com\\.googlecode\\.iterm2$"
+              ]
+            }
+          ],
+          "from": { "key_code": "right_control", "modifiers": { "optional": ["any"] } },
+          "to": [ { "key_code": "right_command" } ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "^com\\.mitchellh\\.ghostty$",
+                "^com\\.apple\\.Terminal$",
+                "^com\\.googlecode\\.iterm2$"
+              ]
+            }
+          ],
+          "from": { "key_code": "right_command", "modifiers": { "optional": ["any"] } },
+          "to": [ { "key_code": "right_control" } ]
         }
       ]
     },
@@ -250,7 +423,7 @@
       ]
     },
     {
-      "description": "Caps Lock to Control (real Control key for CLI/readline/vim/tmux use)",
+      "description": "Caps Lock to Control (kept last so it stays a real Control everywhere, even where Ctrl is swapped to Cmd)",
       "manipulators": [
         {
           "type": "basic",


### PR DESCRIPTION
## 背景

`config/karabiner/windows-style.json` の Windows 風キーマップに 2 つの問題があった。

1. **ターミナルが壊れる**: 適用先を絞っていないため、Ghostty でも `Ctrl+C` が `Cmd+C` になり SIGINT を送れない。`Ctrl+W` はウィンドウを閉じ、Vim の `Ctrl+V`(矩形選択) / `Ctrl+F`(ページ送り) / `Ctrl+W`(ウィンドウ操作) も潰れる。`Home` / `End` も `Cmd+←/→` に化けて端末では効かない。
2. **ショートカットの取りこぼし**: 個別キーを列挙する方式のため、`mandatory: ["control"], optional: []` に該当しないものが素通しになる。`Ctrl+Shift+P`(コマンドパレット)、`Ctrl+Shift+T`、`Ctrl+Shift+I`、`Ctrl+B/I/U/K`、`Ctrl+R`、`Ctrl +/-/0` などが効かない。

## 変更内容

- 個別キー列挙(17 manipulator)を廃止し、**Ctrl ↔ Cmd のモディファイア入れ替え**(4 manipulator)に置換。列挙していなかった Windows ショートカットが原理的に全部通るようになる。
- 入れ替えとナビゲーション系に `frontmost_application_unless` を付与し、Ghostty / Terminal.app / iTerm2 を除外。ターミナル側は `modules/ghostty.nix` が既に Windows Terminal 相当の ctrl 系バインドを持っているため、除外するだけで Windows 風の操作感が揃う。
- `Alt+Tab → Cmd+Tab` を追加。
- 入れ替えより**上**に置く必要があるものを分離:
  - `Ctrl+Tab` / `Ctrl+Shift+Tab`: 入れ替えると `Cmd+Tab`(アプリスイッチャー)になるため、タブ切り替えとして保護。
  - `Ctrl+Y`: macOS に `Cmd+Y` の redo が無いため `Cmd+Shift+Z` へ。
- `Win+L`(ロック) / `Win+Shift+S`(スクショ) は Cmd 側トリガのため、ターミナル込みで常時有効のまま。
- `Caps Lock → Control` は最後に据え置き。入れ替えが効くアプリでも Caps Lock だけは本物の Ctrl として残るので、VS Code の統合ターミナルなど除外リスト外でも `Caps+C` で SIGINT を送れる。

IME ルールと Caps Lock ルールは変更なし。

## 動作確認

- `jq` で JSON の妥当性とルール構成を確認。`.nix` の変更は無し(`modules/karabiner.nix` はパス参照のみ)。
- 実機での確認が必要な点:
  - [ ] ブラウザで `Ctrl+L` がアドレスバーになる(画面ロックしない)
  - [ ] `Ctrl+Tab` がタブ切り替えになる(アプリスイッチャーが出ない)
  - [ ] Ghostty で `Ctrl+C` が中断、`Ctrl+Shift+C/V` がコピペ
  - [ ] `Alt+Tab` の単発切り替え(押しっぱなしでの循環は Karabiner の制約で効かない可能性あり)

🤖 Generated with [Claude Code](https://claude.com/claude-code)