### PR TITLE
feat: macOS に AltTab と Google 日本語入力を cask で追加する

### DIFF
--- a/modules/darwin/default.nix
+++ b/modules/darwin/default.nix
@@ -18,6 +18,10 @@
       "docker-desktop"
       # 拡張機能の管理と自動更新を VSCode 自身に任せたいため cask で導入する。
       "visual-studio-code"
+      # アクセシビリティ権限の付与が必要な GUI アプリのため cask で導入する。
+      "alt-tab"
+      # 入力ソースとしてシステムへの登録が必要なため cask で導入する。
+      "google-japanese-ime"
     ];
   };
 }


### PR DESCRIPTION
## 概要

macOS(nix-darwin)の Homebrew casks に以下を追加した。

- `alt-tab`: Windows 風のウィンドウ切り替え
- `google-japanese-ime`: 日本語入力

どちらも権限付与やシステムへの登録が必要な GUI アプリのため、nix パッケージではなく cask で導入する方針に合わせた。

## 変更後の手動作業

- AltTab: 初回起動時にアクセシビリティ権限の許可が必要
- Google 日本語入力: システム設定 → キーボード → 入力ソースで追加

## 検証

- `nixfmt --check modules/darwin/default.nix` OK
- cask 名は Homebrew/homebrew-cask に存在することを確認済み
- Home Manager 側の変更はないため `home-manager build` の対象外

🤖 Generated with [Claude Code](https://claude.com/claude-code)