### PR TITLE
fix: macOS の Home Manager アプリを実体コピーして Spotlight から探せるようにする

### DIFF
--- a/docs-site/src/setup.md
+++ b/docs-site/src/setup.md
@@ -73,7 +73,7 @@ darwin-rebuild switch --flake .#<エントリ名>
 
 macOS ではターミナルとして Ghostty を導入します([`modules/ghostty.nix`](../../modules/ghostty.nix))。タブ・分割まわりのキーバインドは Windows Terminal に合わせてあります。
 
-- アプリ本体は `~/Applications/Home Manager Apps/Ghostty.app` に symlink されます。Spotlight や Launchpad から見つからない場合は `targets.darwin.copyApps.enable` で実体コピーに切り替えてください。
+- アプリ本体は `~/Applications/Home Manager Apps/Ghostty.app` に実体コピーされます(`targets.darwin.copyApps.enable`)。symlink のままだと Spotlight がインデックスせず、Spotlight や Launchpad から見つからないためです。
 - 設定は `~/.config/ghostty/config` に生成されます。`darwin-rebuild switch` のたびに `ghostty +validate-config` で検証されるため、キー名を間違えると切り替え時に検出されます。
 
 ## 日常操作

--- a/modules/ghostty.nix
+++ b/modules/ghostty.nix
@@ -1,11 +1,16 @@
 { pkgs, ... }:
 {
+  # 既定の linkApps は .app を /nix/store への symlink として置くだけで、Spotlight は
+  # symlink 先を辿らないため Ghostty.app がインデックスされない。実体コピーに切り替えて
+  # Spotlight と Launchpad から起動できるようにする。両者は同じ
+  # ~/Applications/Home Manager Apps/ を使うため linkApps は無効にする。
+  targets.darwin.linkApps.enable = false;
+  targets.darwin.copyApps.enable = true;
+
   # macOS 標準ターミナルの代替。キーバインドは普段使いの Windows Terminal に合わせる。
   programs.ghostty = {
     enable = true;
     # pkgs.ghostty は Linux 専用のため、Mac では公式 dmg を再パッケージした ghostty-bin を使う。
-    # .app は ~/Applications/Home Manager Apps/ に symlink される。Spotlight が拾わない場合は
-    # targets.darwin.copyApps.enable で実体コピーに切り替える。
     package = pkgs.ghostty-bin;
 
     settings = {


### PR DESCRIPTION
## 概要
- Ghostty が dotfiles から入っていないように見えた原因は、`targets.darwin.linkApps`（既定）が `.app` を `/nix/store` への symlink として置くだけで、Spotlight が symlink 先を辿らずインデックスしないことだった。CLI や設定ファイルは正常に配備されていた
- `targets.darwin.copyApps.enable = true` に切り替えて `~/Applications/Home Manager Apps/` に実体を配置する。両オプションは既定ディレクトリが同じで競合するため `linkApps` は無効にする
- 影響範囲は macOS の home-manager 経由で配備される `.app` のみ（現状 Ghostty のみ）。Linux 側には影響しない

## 確認事項
- `nix build .#darwinConfigurations.yuki-maruyama.system` が成功し、activation に `copyApps` が入ることを確認
- 変更前の実機状態も確認済み: `ghostty --version` は 1.3.1 で動作、`~/.config/ghostty/config` も配備済み、一方 `mdfind -name Ghostty.app` は 0 件で Spotlight 未インデックスだった
- `.#homeConfigurations.testuser` と `.#darwinConfigurations.testuser-darwin` は手元の aarch64-darwin ではビルドできない（前者は x86_64-linux、後者は linux 専用パッケージを参照）。stash して確認したところ変更前から同じ失敗のため、本 PR とは無関係。CI での結果を確認したい

## 補足
- macOS 15 以降は `~/Applications` への実体コピーに「App 管理」権限が必要な場合がある。権限不足なら home-manager の `checkAppManagementPermission` が switch 時に警告を出す
- generation ごとに `.app` の実体コピーが発生するため、symlink 運用よりディスク使用量は増える

🤖 Generated with Claude Code