### PR TITLE
fix: JIS 配列でも Ghostty の Alt+Shift++ で右分割できるようにする

### DIFF
--- a/modules/ghostty.nix
+++ b/modules/ghostty.nix
@@ -38,7 +38,10 @@
         "ctrl+alt+digit_9=last_tab"
 
         # 分割(Windows Terminal の Alt+Shift++ / Alt+Shift+- / Alt+Shift+D)
+        # equal / semicolon はどちらも物理キー名。`+` の位置が US 配列では equal、
+        # JIS 配列では semicolon なので、両方に同じ動作を割り当てる。
         "alt+shift+equal=new_split:right"
+        "alt+shift+semicolon=new_split:right"
         "alt+shift+minus=new_split:down"
         "alt+shift+d=new_split:auto"
 


### PR DESCRIPTION
## 概要
- Ghostty の `equal` は文字ではなく W3C の物理キー名として解釈されるため、`alt+shift+equal` は US 配列の `+` の位置しか拾えていなかった。JIS 配列では `+` は `;` キー(物理キー名 `semicolon`)にあるので、Alt+Shift++ を押しても `new_split:right` が発火しない。
- 物理キーの違いを吸収するため、`alt+shift+semicolon=new_split:right` を追加した。
- 影響は Ghostty のキーバインドのみ。US 配列側の既存バインドはそのまま残しているので、どちらの配列でも右分割できる。

## 確認事項
- `ghostty +show-config --docs` のキーバインド仕様で、単一 Unicode 文字でない `equal` は W3C 物理キーコードとして解釈されることを確認した。`ghostty +list-keybinds` の出力でも、既定バインドは文字表記(`super+ctrl+=`)、この設定は物理キー表記(`alt+shift+equal`)と区別して表示される。
- `ghostty +validate-config --config-file=...` で `alt+shift+semicolon` が有効なトリガーとしてパースされることを確認した(Ghostty 1.3.1)。
- `nixfmt modules/ghostty.nix` を適用済み。
- `home-manager build --flake .#testuser` は `testuser` が x86_64-linux 向けのため aarch64-darwin では platform mismatch でビルドできない。代わりに `nix eval .#darwinConfigurations.testuser-darwin...programs.ghostty.settings.keybind` で評価が通り、新しいバインドが出力に含まれることを確認した。Linux 側のビルド確認は CI に委ねる。

## 補足
- 同じ理由で `ctrl+equal=increase_font_size:1` も JIS 配列では `+` キーではなく `^` キー側に割り当たっている。フォントサイズ側も揃えるかは別途判断が必要。

🤖 Generated with Claude Code