### PR TITLE
feat: Ghostty の日本語フォントを Hiragino Sans にして文字サイズを上げる

### DIFF
--- a/modules/ghostty.nix
+++ b/modules/ghostty.nix
@@ -14,6 +14,20 @@
     package = pkgs.ghostty-bin;
 
     settings = {
+      # 既定では英字が内蔵 JetBrains Mono、日本語が BIZ UDGothic へ自動フォールバックし、
+      # 字形が揃わない。内蔵 JetBrains Mono は名前で指定できず(指定しても解決されず次の
+      # 候補が primary に繰り上がる)、日本語だけ差し替えることはできないため、
+      # primary も macOS 同梱の Menlo に明示する。
+      # Nerd Font のアイコンは Ghostty 内蔵の Symbols Nerd Font から供給されるので、
+      # primary を変えても崩れない。
+      # Hiragino Sans は等幅ではないが、かな・漢字の送り幅は 1em 固定で、Ghostty は
+      # 全角文字を 2 セルに収めるため桁はずれない。
+      font-family = [
+        "Menlo"
+        "Hiragino Sans"
+      ];
+      font-size = 15;
+
       # これを有効にしないと Option が特殊文字入力に使われ、alt+... のバインドが効かない。
       macos-option-as-alt = true;
 


### PR DESCRIPTION
## 概要
- Ghostty は既定で英字が内蔵 JetBrains Mono、日本語が BIZ UDGothic への自動フォールバックになり、書体の系統が揃わず日本語が読みづらかった。日本語を macOS 同梱の Hiragino Sans に統一する
- 内蔵 JetBrains Mono は名前で指定できず、`font-family` に書いても解決されずに次の候補が primary へ繰り上がる。日本語だけを差し替えることはできないため、primary も macOS 同梱の Menlo に明示する
- あわせて既定の 13 では小さかった `font-size` を 15 に上げる
- 影響範囲は `modules/ghostty.nix` のみ。新しいフォントのインストールは不要で、すべて macOS 同梱フォントを使う

## 確認事項
- `nixfmt` を適用済み
- `nix build .#darwinConfigurations.yuki-maruyama.system` が成功し、生成された `.config/ghostty/config` に `font-family = Menlo` / `font-family = Hiragino Sans` / `font-size = 15` の 3 行が出力されることを確認
- `ghostty +validate-config` を生成後の config に対して実行し、エラーが出ないことを確認
- `ghostty +show-face` で実際の解決先を確認。英数字・記号は Menlo、かな・漢字は Hiragino Sans、Nerd Font のアイコン (U+F09B, U+F015 など) は Ghostty 内蔵の Symbols Nerd Font から供給され、primary を Menlo に変えてもアイコンは崩れない
- `testuser` と `testuser-darwin` はビルドできていない。前者は x86_64-linux 専用、後者は `modules/grafana-mcp.nix` の mcp-grafana が Linux 専用のため aarch64-darwin では評価が拒否される。どちらも変更前の main でも同じように失敗するため、この変更とは無関係な既存の問題

## 補足
- Hiragino Sans は等幅フォントではないが、かな・漢字の送り幅は 1em 固定で、Ghostty は全角文字を 2 セルに収めるため罫線や表の桁はずれない
- `font-size` の 15 は既定 13 からの控えめな引き上げ。`ctrl+equal` / `ctrl+minus` が既にバインドされているので、実際の見た目に応じて後から調整できる
- 英字と日本語で書体の系統が違う点が気になる場合は、nixpkgs の UDEV Gothic NF (JetBrains Mono + BIZ UDGothic の合成) を入れて 1 ファミリに統一する選択肢もある。字形は揃うがフォントのインストールが増えるため、今回は同梱フォントのみで対応した

🤖 Generated with Claude Code