### PR TITLE
feat: Ghostty の文字サイズを 18 に上げる

### DIFF
--- a/modules/ghostty.nix
+++ b/modules/ghostty.nix
@@ -26,7 +26,7 @@
         "Menlo"
         "Hiragino Sans"
       ];
-      font-size = 15;
+      font-size = 18;
 
       # これを有効にしないと Option が特殊文字入力に使われ、alt+... のバインドが効かない。
       macos-option-as-alt = true;


### PR DESCRIPTION
## 概要
- `modules/ghostty.nix` の `font-size` を 15 から 18 に変更
- 15 でもまだ小さく、長時間の作業で目が疲れるため
- 影響範囲は Ghostty の表示のみ。フォントファミリやキーバインドは変更なし

## 確認事項
- `nixfmt modules/ghostty.nix` を適用し、差分は 1 行のみであることを確認
- `nix build --no-link .#homeConfigurations.testuser.activationPackage` が成功することを確認
- 数値 1 つの変更のため、追加の動作検証は行っていない

🤖 Generated with Claude Code