### PR TITLE
feat(claude): Stop フックで通知を送るようにする

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -37,6 +37,16 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/notify.sh"
+          }
+        ]
+      }
     ]
   },
   "statusLine": {


### PR DESCRIPTION
## 概要
- `permissions.defaultMode: auto` により、ほとんどの操作が確認なしで実行されるようになった結果、既存の Notification フック (`permission_prompt`/`idle_prompt`) がほとんど発火せず、通知が来ないと感じる状態になっていた
- タスク完了 (`Stop`) イベントにも `notify.sh` を紐付け、確認プロンプトの有無にかかわらず通知が届くようにした

## 確認事項
- `jq . config/claude/settings.json` で JSON として妥当なことを確認
- `notify.sh` をサンドボックス外で直接実行し、exit 0 で正常終了することを確認（WSL interop 経由の toast 通知自体は動作している）
- Notification hook はハーネスが直接起動するため sandbox 設定の影響を受けないことを確認済み。`Stop` hook も同様の経路のため、追加設定のみで機能する見込み

🤖 Generated with Claude Code