### PR TITLE
feat(claude): output style を Concise に設定する

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "outputStyle": "Concise",
   "worktreeConfig": {
     "enabled": true
   },


### PR DESCRIPTION
## 概要
- Claude Code の output style を `Concise` に設定
- 対象は `config/claude/settings.json`（home-manager が `~/.claude/settings.json` として配備する正本）
- https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21237 で追加された組み込み output style を利用する

## 確認事項
- 設定ファイルへの追記のみで、動作検証を伴う変更ではないため追加検証は行っていない
- ユーザーの指示により `home-manager switch` による反映は今回実施していない

🤖 Generated with Claude Code