### PR TITLE
chore: antigravity-cli を削除する

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,6 @@
           "copilot.vim"
           "copilot-cli"
           "barbar.nvim"
-          "antigravity-cli"
         ];
       mkPkgs =
         system:

--- a/modules/llm-agents.nix
+++ b/modules/llm-agents.nix
@@ -10,7 +10,6 @@ let
       pkgs.llm-agents.ccusage
       pkgs.llm-agents.copilot-cli
       pkgs.llm-agents.codex
-      pkgs.llm-agents.antigravity-cli
       pkgs.llm-agents.opencode
     ];
     work = [ ];


### PR DESCRIPTION
## 概要
- personal profile の home.packages と flake.nix の unfree allowlist から antigravity-cli を除去

## 確認事項
- `home-manager build --flake .#testuser` が成功することを確認
- `nixfmt` を適用済み

🤖 Generated with Claude Code